### PR TITLE
Allocate the DNSServer and ESP8266WebServer on the heap at begin() time and free them when autoConnect() terminates.

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -18,7 +18,7 @@
 //#include <WiFiClient.h>
 #include <ESP8266WebServer.h>
 #include <DNSServer.h>
-
+#include <memory>
 
 class WiFiManager
 {
@@ -56,8 +56,8 @@ public:
     int     serverLoop();
 
 private:
-    DNSServer dnsServer;
-    ESP8266WebServer server;
+    std::unique_ptr<DNSServer> dnsServer;
+    std::unique_ptr<ESP8266WebServer> server;
 
     const int WM_DONE = 0;
     const int WM_WAIT = 10;


### PR DESCRIPTION
This reduces the likelihood of a stack overflow when WifiManager is instantiated in setup(),
and lowers memory usage (after WiFi is connected) when it's instantiated globally.