### PR TITLE
Manually starting the configuration portal

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -16,14 +16,6 @@
 WiFiManager::WiFiManager() {
 }
 
-void WiFiManager::begin() {
-  begin("NoNetESP");
-}
-
-void WiFiManager::begin(char const *apName) {
-  begin(apName,NULL);
-}
-
 void WiFiManager::begin(char const *apName, char const *apPasswd) {
   dnsServer.reset(new DNSServer());
   server.reset(new ESP8266WebServer(80));
@@ -113,7 +105,6 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd) {
   connect = false;
   begin(apName,apPasswd);
 
-  bool looping = true;
   while(timeout == 0 || millis() < start + timeout) {
     //DNS
     dnsServer->processNextRequest();
@@ -174,40 +165,6 @@ String WiFiManager::getPassword() {
   }
   return _pass;
 }
-
-/*
-String WiFiManager::getEEPROMString(int start, int len) {
-  EEPROM.begin(512);
-  delay(10);
-  String string = "";
-  for (int i = _eepromStart + start; i < _eepromStart + start + len; i++) {
-    //DEBUG_PRINT(i);
-    string += char(EEPROM.read(i));
-  }
-  EEPROM.end();
-  return string;
-}
-*/
-/*
-void WiFiManager::setEEPROMString(int start, int len, String string) {
-  EEPROM.begin(512);
-  delay(10);
-  int si = 0;
-  for (int i = _eepromStart + start; i < _eepromStart + start + len; i++) {
-    char c;
-    if (si < string.length()) {
-      c = string[si];
-      //DEBUG_PRINT(F("Wrote: ");
-      //DEBUG_PRINT(c);
-    } else {
-      c = 0;
-    }
-    EEPROM.write(i, c);
-    si++;
-  }
-  EEPROM.end();
-  DEBUG_PRINT(F("Wrote " + string);
-}*/
 
 String WiFiManager::urldecode(const char *src)
 {

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -76,25 +76,25 @@ boolean WiFiManager::autoConnect(char const *apName) {
   return autoConnect(apName,NULL);
 }
 
-boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd) {
+boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd, bool forceAP) {
   DEBUG_PRINT(F(""));
   DEBUG_PRINT(F("AutoConnect"));
   
   // read eeprom for ssid and pass
   String ssid = getSSID();
   String pass = getPassword();
-  //use SDK functions to get SSID and pass
-  //String ssid = WiFi.SSID();
-  //String pass = WiFi.psk();
-  
-  WiFi.mode(WIFI_STA);
-  if(connectWifi(ssid, pass) == WL_CONNECTED)   {
-    DEBUG_PRINT(F("IP Address:"));
-    DEBUG_PRINT(WiFi.localIP());
-    //connected
-    return true;
+
+  if ( ! forceAP ) {
+	  // attempt to connect; should it fail, fall back to AP
+	  WiFi.mode(WIFI_STA);
+	  if(connectWifi(ssid, pass) == WL_CONNECTED)   {
+		DEBUG_PRINT(F("IP Address:"));
+		DEBUG_PRINT(WiFi.localIP());
+		//connected
+		return true;
+	  }
   }
- 
+  
   //not connected
   //setup AP
   WiFi.mode(WIFI_AP);

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -96,9 +96,7 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd) {
   //String pass = WiFi.psk();
   
   WiFi.mode(WIFI_STA);
-  connectWifi(ssid, pass);
-  int s = WiFi.status();
-  if (s == WL_CONNECTED) {
+  if(connectWifi(ssid, pass) == WL_CONNECTED)   {
     DEBUG_PRINT(F("IP Address:"));
     DEBUG_PRINT(WiFi.localIP());
     //connected
@@ -127,16 +125,9 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd) {
       delay(2000);
       DEBUG_PRINT(F("Connecting to new AP"));
       connect = false;
-      //ssid = getSSID();
-      //pass = getPassword();
-      connectWifi(_ssid, _pass);
-      int s = WiFi.status();
-      if (s != WL_CONNECTED) {
+      // using user-provided  _ssid, _pass in place of system-stored ssid amd pass
+      if (connectWifi(_ssid, _pass) != WL_CONNECTED) {
         DEBUG_PRINT(F("Failed to connect."));
-        //not connected, should retry everything
-        //ESP.reset();
-        //delay(1000);
-        //return false;
       } else {
         //connected 
         WiFi.mode(WIFI_STA);
@@ -153,13 +144,14 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPasswd) {
 }
 
 
-void WiFiManager::connectWifi(String ssid, String pass) {
+int WiFiManager::connectWifi(String ssid, String pass) {
   DEBUG_PRINT(F("Connecting as wifi client..."));
   //WiFi.disconnect();
   WiFi.begin(ssid.c_str(), pass.c_str());
   int connRes = WiFi.waitForConnectResult();
   DEBUG_PRINT ("Connection result: ");
   DEBUG_PRINT ( connRes );
+  return connRes;
 }
 
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -38,7 +38,7 @@ public:
         
     boolean autoConnect();
     boolean autoConnect(char const *apName);
-    boolean autoConnect(char const *apName, char const *apPasswd);
+    boolean autoConnect(char const *apName, char const *apPasswd, bool forceAP = false);
 
     String  getSSID();
     String  getPassword();

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -101,7 +101,7 @@ private:
 
     bool keepLooping = true;
     int status = WL_IDLE_STATUS;
-    void connectWifi(String ssid, String pass);
+    int connectWifi(String ssid, String pass);
 
     void handleRoot();
     void handleWifi(bool scan);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -13,9 +13,6 @@
 #define WiFiManager_h
 
 #include <ESP8266WiFi.h>
-
-//#include <EEPROM.h>
-//#include <WiFiClient.h>
 #include <ESP8266WebServer.h>
 #include <DNSServer.h>
 #include <memory>


### PR DESCRIPTION
My hardware has a button to trigger configuration, so I needed a way to force the captive portal regardless of running configuration. So I added a third (defaulted) parameter to autoconnect(), namely forceAP. It is defaulted to false, for backward compatibility; but if it set to true, the captive portal is started without even attempting to connect with current SSID and password.

In the works, I have cleaned up some commented/unused code and changed connectWifi() to return the connection status, getting rid of temprary 's' varibles that were used to read status again right after a call to connectWifi().