### PR TITLE
On-demand example now compatible with ESP-01 boards

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -49,13 +49,11 @@ void WiFiManager::addParameter(WiFiManagerParameter *p) {
   DEBUG_WM(p->getID());
 }
 
-void WiFiManager::setupConfigPortal(char const *apName, char const *apPassword) {
+void WiFiManager::setupConfigPortal() {
   dnsServer.reset(new DNSServer());
   server.reset(new ESP8266WebServer(80));
 
   DEBUG_WM(F(""));
-  _apName = apName;
-  _apPassword = apPassword;
   start = millis();
 
   DEBUG_WM(F("Configuring access point... "));
@@ -130,14 +128,17 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
   //setup AP
   WiFi.mode(WIFI_AP);
   
+  _apName = apName;
+  _apPassword = apPassword;
+
   //notify we entered AP mode
   if ( _apcallback != NULL) {
     _apcallback();
   }
   
   connect = false;
-  setupConfigPortal(apName, apPassword);
-
+  setupConfigPortal();
+  DEBUG_WM("start loop");
   while (timeout == 0 || millis() < start + timeout) {
     //DNS
     dnsServer->processNextRequest();
@@ -169,7 +170,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
 
   server.reset();
   dnsServer.reset();
-
+  DEBUG_WM("end loop");
   return  WiFi.status() == WL_CONNECTED;
 }
 
@@ -203,6 +204,10 @@ String WiFiManager::getPassword() {
     //DEBUG_WM(_pass);
   }
   return _pass;
+}
+
+String WiFiManager::getConfigPortalSSID() {
+  return _apName;
 }
 
 String WiFiManager::urldecode(const char *src)
@@ -476,7 +481,6 @@ void WiFiManager::DEBUG_WM(Generic text) {
     Serial.println(text);
   }
 }
-
 
 int WiFiManager::getRSSIasQuality(int RSSI) {
   int quality = 0;

--- a/examples/OnDemandConfigPortal/OnDemandConfigPortal.ino
+++ b/examples/OnDemandConfigPortal/OnDemandConfigPortal.ino
@@ -1,8 +1,6 @@
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
 
 //needed for library
-#include <DNSServer.h>
-#include <ESP8266WebServer.h>
 #include <WiFiManager.h>          //https://github.com/tzapu/WiFiManager
 
 

--- a/examples/OnDemandConfigPortal/OnDemandConfigPortal.ino
+++ b/examples/OnDemandConfigPortal/OnDemandConfigPortal.ino
@@ -3,6 +3,10 @@
 //needed for library
 #include <WiFiManager.h>          //https://github.com/tzapu/WiFiManager
 
+// select wich pin will trigger the configuraton portal when set to LOW
+// ESP-01 users please note: the only pins available (0 and 2), are shared 
+// with the bootloader, so always set them HIGH at power-up
+#define TRIGGER_PIN 0
 
 //callback notifying us of the need to save config
 void saveConfigCallback () {
@@ -15,12 +19,13 @@ void setup() {
   Serial.begin(115200);
   Serial.println("\n Starting");
 
-  //read gpio 4 state on startup
-  pinMode(4, INPUT);
-  int pinState = digitalRead(4);
+  pinMode(TRIGGER_PIN, INPUT);
+}
 
-  //if gpio 4 is high startup config mode
-  if (pinState == LOW) {
+
+void loop() {
+  // is configuration portal requested?
+  if ( digitalRead(TRIGGER_PIN) == LOW ) {
     //WiFiManager
     //Local intialization. Once its business is done, there is no need to keep it around
     WiFiManager wifiManager;
@@ -56,10 +61,6 @@ void setup() {
   }
 
 
-}
-
-void loop() {
   // put your main code here, to run repeatedly:
-
 
 }


### PR DESCRIPTION
Changed to make it work on ESP-01 boards.
It turn out that on ESP-01, the pin cannot be checked at setup as its only available pins, gpio0 and gpio2, are shared with the bootloader and **must** be kept HIGH at power-up.
- moved triggering of configuration portal into Arduino's loop() function
- changed pin from 4 to 0 (and made it  #define-able)