### PR TITLE
Added parameter to callback

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -133,7 +133,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
 
   //notify we entered AP mode
   if ( _apcallback != NULL) {
-    _apcallback();
+    _apcallback(this);
   }
   
   connect = false;
@@ -463,7 +463,7 @@ boolean WiFiManager::captivePortal() {
 }
 
 //start up config portal callback
-void WiFiManager::setAPCallback( void (*func)(void) ) {
+void WiFiManager::setAPCallback( void (*func)(WiFiManager* myWiFiManager) ) {
   _apcallback = func;
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -83,7 +83,7 @@ class WiFiManager
     //sets a custom ip /gateway /subnet configuration
     void          setAPConfig(IPAddress ip, IPAddress gw, IPAddress sn);
     //called when AP mode and config portal is started
-    void          setAPCallback( void (*func)(void) );
+    void          setAPCallback( void (*func)(WiFiManager*) );
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
 
@@ -138,7 +138,7 @@ class WiFiManager
     boolean       connect;
     boolean       _debug = true;
 
-    void (*_apcallback)(void) = NULL;
+    void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
 
     WiFiManagerParameter* _params[WIFI_MANAGER_MAX_PARAMS];

--- a/examples/AutoConnectWithFeedback/AutoConnectWithFeedback.ino
+++ b/examples/AutoConnectWithFeedback/AutoConnectWithFeedback.ino
@@ -5,15 +5,11 @@
 #include <ESP8266WebServer.h>
 #include "WiFiManager.h"          //https://github.com/tzapu/WiFiManager
 
-//WiFiManger
-//global intialization: this wastes memory, only used here to have access to wifiManager.getConfigPortalSSID()
-WiFiManager wifiManager;
-
-void configModeCallback () {
+void configModeCallback (WiFiManager *myWiFiManager) {
   Serial.println("Entered config mode");
   Serial.println(WiFi.softAPIP());
   //if you used auto generated SSID, print it
-  Serial.println(wifiManager.getConfigPortalSSID());
+  Serial.println(myWiFiManager->getConfigPortalSSID());
 }
 
 void setup() {
@@ -22,7 +18,7 @@ void setup() {
   
   //WiFiManager
   //Local intialization. Once its business is done, there is no need to keep it around
-  //WiFiManager wifiManager;
+  WiFiManager wifiManager;
   //reset settings - for testing
   //wifiManager.resetSettings();
 


### PR DESCRIPTION
To show the config portal SSID in the callback, a global reference to the WiFiManager object was needed. To solve this, a pointer to the WiFiManager object is now passed to the callback. The feedback example is edited accordingly.

This does break backward compatibility though, but saves memory.