### PR TITLE
Fixed typo in  library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
     "url": "http://tzapu.com"
   },
   "frameworks": "arduino",
-  "platforms": "esp8266"
+  "platforms": "esp8266",
   "version": "0.6", 
-  "architecture": "esp8266",
+  "architecture": "esp8266"
 }


### PR DESCRIPTION
Added missing comma that made the JSON invalid. Noticed this while trying to use the lib in platformio.