### PR TITLE
Added an option to the WiFiManagerParameter so that a form parameter can be…

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -12,7 +12,8 @@
 
 #include "WiFiManager.h"
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length) {
+  
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length, int rofield) {
   _id = id;
   _placeholder = placeholder;
   _length = length;
@@ -23,6 +24,25 @@ WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placehold
   if (defaultValue != NULL) {
     strncpy(_value, defaultValue, length);
   }
+  if (rofield == 0) {
+    _rofield = " readonly";
+  } else {
+    _rofield = "";
+  }
+}
+
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length) {
+ _id = id;
+  _placeholder = placeholder;
+  _length = length;
+  _value = new char[length + 1];
+  for (int i = 0; i < length; i++) {
+    _value[i] = 0;
+  }
+  if (defaultValue != NULL) {
+    strncpy(_value, defaultValue, length);
+  }
+  _rofield = "";
 }
 
 const char* WiFiManagerParameter::getValue() {
@@ -36,6 +56,9 @@ const char* WiFiManagerParameter::getPlaceholder() {
 }
 int WiFiManagerParameter::getValueLength() {
   return _length;
+}
+const char* WiFiManagerParameter::getRofield() {
+  return _rofield;
 }
 
 WiFiManager::WiFiManager() {
@@ -415,6 +438,7 @@ void WiFiManager::handleWifi(boolean scan) {
     snprintf(parLength, 2, "%d", _params[i]->getValueLength());
     pitem.replace("{l}", parLength);
     pitem.replace("{v}", _params[i]->getValue());
+    pitem.replace("{r}", _params[i]->getRofield());
 
     page += pitem;
   }
@@ -679,5 +703,3 @@ String WiFiManager::toStringIp(IPAddress ip) {
   res += String(((ip >> 8 * 3)) & 0xFF);
   return res;
 }
-
-

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -28,7 +28,7 @@ const char HTTP_PORTAL_OPTIONS[] PROGMEM = "<form action=\"/wifi\" method=\"get\
 const char HTTP_ITEM[] PROGMEM = "<div><a href='#' onclick='c(this)'>{v}</a>&nbsp;<span class='q {i}'>{r}%</span></div>";
 //const char HTTP_ITEM_PADLOCK[] PROGMEM = "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAALVBMVEX///8EBwfBwsLw8PAzNjaCg4NTVVUjJiZDRUUUFxdiZGSho6OSk5Pg4eFydHTCjaf3AAAAZElEQVQ4je2NSw7AIAhEBamKn97/uMXEGBvozkWb9C2Zx4xzWykBhFAeYp9gkLyZE0zIMno9n4g19hmdY39scwqVkOXaxph0ZCXQcqxSpgQpONa59wkRDOL93eAXvimwlbPbwwVAegLS1HGfZAAAAABJRU5ErkJggg==' width='13px'/>";
 const char HTTP_FORM_START[] PROGMEM = "<form method='get' action='wifisave'><input id='s' name='s' length=32 placeholder='SSID'><br/><input id='p' name='p' length=64 type='password' placeholder='password'><br/>";
-const char HTTP_FORM_PARAM[] PROGMEM = "<br/><input id='{i}' name='{n}' length={l} placeholder='{p}' value='{v}'>";
+const char HTTP_FORM_PARAM[] PROGMEM = "<br/><input id='{i}' name='{n}' length={l} placeholder='{p}' value='{v}' {r}>";
 const char HTTP_FORM_END[] PROGMEM = "<br/><button type='submit'>save</button></form>";
 const char HTTP_SCAN_LINK[] PROGMEM = "<br/><div class=\"c\"><a href=\"/wifi\">Scan</a></div>";
 
@@ -40,16 +40,19 @@ const char HTTP_END[] PROGMEM = "</div></body></html>";
 class WiFiManagerParameter {
   public:
     WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length);
+    WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length, int rofield);
 
     const char *getID();
     const char *getValue();
     const char *getPlaceholder();
     int         getValueLength();
+    const char *getRofield();
   private:
     const char *_id;
     const char *_placeholder;
     char       *_value;
     int         _length;
+    const char *_rofield;
 
     friend class WiFiManager;
 };


### PR DESCRIPTION
Added an option to the WiFiManagerParameter so that a form parameter can be read-only. This is done in a way that does not break an existing program by having a constructor for either way. 
If a "1" is added to the end of the parameter list then the field becomes readonly.
The HTML will add the "readonly" option.

My need for this is that I am using the MAC address as a ClientID in a MQTT application. I wanted the 
user to know the mac without being able to modify it.

It is a relatively simple change, but I hope that you can use it.