### PR TITLE
give option for static OR dynamic

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -215,6 +215,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
   DEBUG_WM(F("Connecting as wifi client..."));
 
   // check if we've got static_ip settings, if we do, use those.
+  //TODO - should we be checking that we have a gw and sn? What happens if not?
   if (_sta_static_ip) {
     DEBUG_WM(F("Custom STA IP/GW/Subnet"));
     WiFi.config(_sta_static_ip, _sta_static_gw, _sta_static_sn);
@@ -466,14 +467,22 @@ void WiFiManager::handleWifi(boolean scan) {
     page += "<br/>";
   }
 
-  if (_sta_static_ip) {
+  //added in check to see if we should force a static IP selection
+  if (_sta_static_ip || _forceStaticIPconfig) {
 
     String item = FPSTR(HTTP_FORM_PARAM);
     item.replace("{i}", "ip");
     item.replace("{n}", "ip");
-    item.replace("{p}", "Static IP");
+	if (_forceStaticIPconfig)
+		item.replace("{p}", "Static IP (blank for DHCP)");
+	else
+		item.replace("{p}", "Static IP");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_ip.toString());
+	if (_sta_static_ip)
+		item.replace("{v}", _sta_static_ip.toString());
+	else
+		item.replace("{v}", "");
+
 
     page += item;
 
@@ -482,7 +491,10 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "gw");
     item.replace("{p}", "Static Gateway");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_gw.toString());
+	if (_sta_static_gw)
+		item.replace("{v}", _sta_static_gw.toString());
+	else
+		item.replace("{v}", "");
 
     page += item;
 
@@ -491,7 +503,10 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "sn");
     item.replace("{p}", "Subnet");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_sn.toString());
+	if (_sta_static_sn)
+		item.replace("{v}", _sta_static_sn.toString());
+	else
+		item.replace("{v}", "");
 
     page += item;
 
@@ -688,7 +703,18 @@ void WiFiManager::setCustomHeadElement(const char* element) {
   _customHeadElement = element;
 }
 
+//forces the display of a static IP even if we don't send one - this means user can changes between DHCP and static
+void WiFiManager::setForceStaticIPconfig(boolean force)
+{
+	_forceStaticIPconfig = force;
+}
 
+//returns true if we have all the bits needed to make a static config
+boolean WiFiManager::getSTAIsStaticIP()
+{
+	return (_sta_static_ip && _sta_static_gw && _sta_static_sn);
+		
+}
 
 
 template <typename Generic>

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -108,6 +108,14 @@ class WiFiManager
     //TODO
     //if this is set, customise style
     void          setCustomHeadElement(const char* element);
+	//if this is set, always display inputs for static IP config, but allow them to be blank (Meaning config will be DHCP as normal)
+	void		  setForceStaticIPconfig(boolean force);
+	
+	//making the below public so that we can query them to save after config is done
+	//as far as I can tell there is no way to find out from the WiFi object whether the localIP() is set via static or DHCP
+	//so this allows us to query whether we had a static IP and if so we can get the details from WiFi.localIP() etc and store them in EEPROM manually
+	boolean     getSTAIsStaticIP();
+
 
 
   private:
@@ -141,6 +149,8 @@ class WiFiManager
     int           _minimumQuality         = -1;
     boolean       _shouldBreakAfterConfig = false;
     boolean       _tryWPS                 = false;
+	
+	boolean		  _forceStaticIPconfig    = false;
 
     const char*   _customHeadElement      = "";
 


### PR DESCRIPTION
adds an option to set enableForceStaticIP which when true will always
present the static IP fields - if no static IP is sent these will be
blank. If the user doesn’t fill these in then dhcp will be used. Also
added “getSTAIsStaticIP()” - call this after the save is completed and
query whether the user has set a static IP. This way the sketch can
then save the static IP to EEPROM if required.