### PR TITLE
Adds option to use generated AP name but with password

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,14 @@ if you just want an unsecured access point
 ```cpp
 wifiManager.autoConnect("AP-NAME");
 ```
-or if you want to use and auto generated name from 'ESP' and the esp's Chip ID use
+When working with multiple devices, it can be useful to have unique AP names (based on the esp's Chip ID).
+For this you can use simply omit all arguments to `autoConnect()`, or use `wifiManager.ssidFromId()` when you want to use a password:
 ```cpp
+// use generated AP name, no password
 wifiManager.autoConnect();
+// Use a generated AP name, but also a password
+wifiManager.autoConnect(wifiManager.ssidFromId(), "AP-PASSWORD");
 ```
-
 After you write your sketch and start the ESP, it will try to connect to WiFi. If it fails it starts in Access Point mode.
 While in AP mode, connect to it then open a browser to the gateway IP, default 192.168.4.1, configure wifi, save and it should reboot and connect.
 
@@ -197,7 +200,7 @@ Usage scenario would be:
 - once WiFiManager returns control to your application, read and save the new values using the `WiFiManagerParameter` object.
  ```cpp
  mqtt_server = custom_mqtt_server.getValue();
- ```  
+ ```
 This feature is a lot more involved than all the others, so here are some examples to fully show how it is done
 - Save and load custom parameters to file system in json form [AutoConnectWithFSParameters](https://github.com/tzapu/WiFiManager/tree/master/examples/AutoConnectWithFSParameters)
 - *Save and load custom parameters to EEPROM* (not done yet)

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -123,9 +123,13 @@ void WiFiManager::setupConfigPortal() {
 
 }
 
+const char * WiFiManager::ssidFromId(){
+  String ssid = "ESP_" + String(ESP.getChipId());
+  return ssid.c_str();
+}
+
 boolean WiFiManager::autoConnect() {
-  String ssid = "ESP" + String(ESP.getChipId());
-  return autoConnect(ssid.c_str(), NULL);
+  return autoConnect(ssidFromId(), NULL);
 }
 
 boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -70,6 +70,9 @@ class WiFiManager
   public:
     WiFiManager();
 
+    // Retuns a string that can be used as ssid, based on this ESP's unique ID
+    const char *  ssidFromId();
+
     boolean       autoConnect();
     boolean       autoConnect(char const *apName, char const *apPassword = NULL);
 


### PR DESCRIPTION
This update allows you to use a generated AP name, but also set a password.
`wifiManager.ssidFromId()` returns the generated AP name, so you can use it in the original `autoConnect()` functions:

    // use generated AP name, no password (as before)
    wifiManager.autoConnect();
    // Use a generated AP name, but also a password
    wifiManager.autoConnect(wifiManager.ssidFromId(), "AP-PASSWORD");