### PR TITLE
F/non blocking api

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -79,11 +79,11 @@ void WiFiManager::setupConfigPortal() {
 
   DEBUG_WM(F("Configuring access point... "));
   DEBUG_WM(_apName);
-  if (_apPassword != NULL) {
-    if (strlen(_apPassword) < 8 || strlen(_apPassword) > 63) {
+  if (_apPassword != "") {
+    if (_apPassword.length() < 8 || _apPassword.length() > 63) {
       // fail passphrase to short or long!
       DEBUG_WM(F("Invalid AccessPoint password. Ignoring"));
-      _apPassword = NULL;
+      _apPassword = "";
     }
     DEBUG_WM(_apPassword);
   }
@@ -94,10 +94,10 @@ void WiFiManager::setupConfigPortal() {
     WiFi.softAPConfig(_ap_static_ip, _ap_static_gw, _ap_static_sn);
   }
 
-  if (_apPassword != NULL) {
-    WiFi.softAP(_apName, _apPassword);//password option
+  if (_apPassword != "") {
+    WiFi.softAP(_apName.c_str(), _apPassword.c_str());//password option
   } else {
-    WiFi.softAP(_apName);
+    WiFi.softAP(_apName.c_str());
   }
 
   delay(500); // Without delay I've seen the IP address blank

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -142,8 +142,8 @@ class WiFiManager
     char          currentState            = WIFIMANAGER_STATE_INIT;
     void          processConfigPortal();
 
-    const char*   _apName                 = "no-net";
-    const char*   _apPassword             = NULL;
+    String        _apName                 = "no-net";
+    String        _apPassword             = "";
     String        _ssid                   = "";
     String        _pass                   = "";
     unsigned long _configPortalTimeout    = 0;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -22,6 +22,15 @@ extern "C" {
   #include "user_interface.h"
 }
 
+/**
+ * State constants
+ */
+#define WIFIMANAGER_STATE_INIT             0
+#define WIFIMANAGER_STATE_CONNECTING       1
+#define WIFIMANAGER_STATE_CONFIG_PORTAL   10
+#define WIFIMANAGER_STATE_DEACTIVATED    255
+
+
 const char HTTP_HEAD[] PROGMEM            = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/><title>{v}</title>";
 const char HTTP_STYLE[] PROGMEM           = "<style>.c{text-align: center;} div,input{padding:5px;font-size:1em;} input{width:95%;} body{text-align: center;font-family:verdana;} button{border:0;border-radius:0.3rem;background-color:#1fa3ec;color:#fff;line-height:2.4rem;font-size:1.2rem;width:100%;} .q{float: right;width: 64px;text-align: right;} .l{background: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAALVBMVEX///8EBwfBwsLw8PAzNjaCg4NTVVUjJiZDRUUUFxdiZGSho6OSk5Pg4eFydHTCjaf3AAAAZElEQVQ4je2NSw7AIAhEBamKn97/uMXEGBvozkWb9C2Zx4xzWykBhFAeYp9gkLyZE0zIMno9n4g19hmdY39scwqVkOXaxph0ZCXQcqxSpgQpONa59wkRDOL93eAXvimwlbPbwwVAegLS1HGfZAAAAABJRU5ErkJggg==\") no-repeat left center;background-size: 1em;}</style>";
 const char HTTP_SCRIPT[] PROGMEM          = "<script>function c(l){document.getElementById('s').value=l.innerText||l.textContent;document.getElementById('p').focus();}</script>";
@@ -75,6 +84,9 @@ class WiFiManager
     // get the AP name of the config portal, so it can be used in the callback
     String        getConfigPortalSSID();
 
+    // In non blocking mode call this method from your loop to process next events
+    void          process();
+
     void          resetSettings();
 
     //sets timeout before webserver loop ends and exits even if there has been no setup.
@@ -120,6 +132,9 @@ class WiFiManager
 
     void          setupConfigPortal();
     void          startWPS();
+
+    char          currentState            = WIFIMANAGER_STATE_INIT;
+    void          processConfigPortal();
 
     const char*   _apName                 = "no-net";
     const char*   _apPassword             = NULL;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -147,7 +147,7 @@ class WiFiManager
     String        _ssid                   = "";
     String        _pass                   = "";
     unsigned long _configPortalTimeout    = 0;
-    unsigned long _connectTimeout         = 0;
+    unsigned long _connectTimeout         = 30000;
     unsigned long _configPortalStart      = 0;
     unsigned long _connectionStart        = 0;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -28,6 +28,7 @@ extern "C" {
 #define WIFIMANAGER_STATE_INIT             0
 #define WIFIMANAGER_STATE_CONNECTING       1
 #define WIFIMANAGER_STATE_CONFIG_PORTAL   10
+#define WIFIMANAGER_STATE_CHECKING        11
 #define WIFIMANAGER_STATE_DEACTIVATED    255
 
 
@@ -80,6 +81,11 @@ class WiFiManager
 
     //if you want to always start the config portal, without trying to connect first
     boolean       startConfigPortal(char const *apName, char const *apPassword = NULL);
+
+    // You can stop an already running config portal with this.
+    // It will destroy the web and dns server, and also make shure that
+    // the wifi is in STA mode
+    void          deactivateConfigPortal();
 
     // get the AP name of the config portal, so it can be used in the callback
     String        getConfigPortalSSID();

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -143,6 +143,7 @@ class WiFiManager
     unsigned long _configPortalTimeout    = 0;
     unsigned long _connectTimeout         = 0;
     unsigned long _configPortalStart      = 0;
+    unsigned long _connectionStart        = 0;
 
     IPAddress     _ap_static_ip;
     IPAddress     _ap_static_gw;
@@ -165,6 +166,8 @@ class WiFiManager
     int           status = WL_IDLE_STATUS;
     int           connectWifi(String ssid, String pass);
     uint8_t       waitForConnectResult();
+    void          leaveConnecting(uint8_t status);
+    void          afterConnected();
 
     void          handleRoot();
     void          handleWifi(boolean scan);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -105,6 +105,9 @@ class WiFiManager
     void          setConnectTimeout(unsigned long seconds);
 
 
+    // Turn on non-blocking mode. This should be called before autoConnect
+    void          setNonBlocking(boolean nonBlocking);
+
     void          setDebugOutput(boolean debug);
     //defaults to not showing anything under 8% signal quality if called
     void          setMinimumSignalQuality(int quality = 8);
@@ -142,6 +145,7 @@ class WiFiManager
     char          currentState            = WIFIMANAGER_STATE_INIT;
     void          processConfigPortal();
 
+    boolean       _nonBlocking            = false;
     String        _apName                 = "no-net";
     String        _apPassword             = "";
     String        _ssid                   = "";
@@ -174,6 +178,7 @@ class WiFiManager
     uint8_t       waitForConnectResult();
     void          leaveConnecting(uint8_t status);
     void          afterConnected();
+    boolean       block();
 
     void          handleRoot();
     void          handleWifi(boolean scan);

--- a/examples/AutoConnectNonBlocking/AutoConnectNonBlocking.ino
+++ b/examples/AutoConnectNonBlocking/AutoConnectNonBlocking.ino
@@ -1,0 +1,37 @@
+#include <ESP8266WiFi.h>
+#include <ESP8266WebServer.h>
+#include <WiFiManager.h>
+
+WiFiManager wifiManager;
+
+unsigned long lastTick = 0;
+
+void setup() {
+    // Init serial communication
+    Serial.begin(9600);
+
+    pinMode(BUILTIN_LED, OUTPUT);
+    digitalWrite(BUILTIN_LED, 1);
+
+    lastTick = millis();
+
+    // WifiManager init
+    // Setting the timeouts is not necessary, but encouraged
+    wifiManager.setNonBlocking(true);
+    wifiManager.setConnectTimeout(15);
+    wifiManager.setConfigPortalTimeout(180);
+    wifiManager.autoConnect();
+}
+
+void loop() {
+    // This should be called regularily
+    wifiManager.process();
+
+    yield();
+
+    // Blinking led to prove: the main loop does not get blocked
+    if (millis() - lastTick < 200) return;
+    lastTick = millis();
+    digitalWrite(BUILTIN_LED, !digitalRead(BUILTIN_LED));
+
+}

--- a/examples/AutoConnectNonBlocking/AutoConnectNonBlocking.ino
+++ b/examples/AutoConnectNonBlocking/AutoConnectNonBlocking.ino
@@ -1,3 +1,5 @@
+//needed for library
+#include <DNSServer.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <WiFiManager.h>


### PR DESCRIPTION
Hello,

this update introduces a non-blocking mode for the WiFiManager.

My devices use wifi merely to pull updates, and the don't even have connectivity every time they turn on. So blocking for several minutes with the config portal is not an option: I wanted to have my application run parallel with the config portal.

In this change I've broke down the main blocking functions (connect, portal event handling, portal connection)  into smaller ones, and introduced an internal state maching (_currentState attribute) to keep track of the state.

Default is still the blocking mode, to provide backward compatibility with the original implementation. But in the internals it will do the non-blocking style, but wait before returning.

I've tried to keep the changeset minimal, unfortunately I had modify several functions.

There are still some small blocking events like the scan process, yet I believe they usually don't take more than a few seconds.

There's an example included to show how non-blocking mode can be used.

Any comments and suggestions are welcome.
