### PR TITLE
Fix to allow 5 digit 'mqtt_port'

### DIFF
--- a/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
+++ b/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
@@ -74,7 +74,7 @@ void setup() {
   // After connecting, parameter.getValue() will get you the configured value
   // id/name placeholder/prompt default length
   WiFiManagerParameter custom_mqtt_server("server", "mqtt server", mqtt_server, 40);
-  WiFiManagerParameter custom_mqtt_port("port", "mqtt port", mqtt_port, 5);
+  WiFiManagerParameter custom_mqtt_port("port", "mqtt port", mqtt_port, 6);
   WiFiManagerParameter custom_blynk_token("blynk", "blynk token", blynk_token, 32);
 
   //WiFiManager


### PR DESCRIPTION
'WiFiManagerParameter custom_mqtt_port' made consistent with declaration of 'mqtt_port'