### PR TITLE
startConfigPortal() without any parameters

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -149,6 +149,11 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
   return startConfigPortal(apName, apPassword);
 }
 
+boolean WiFiManager::startConfigPortal() {
+  String ssid = "ESP" + String(ESP.getChipId());
+  return startConfigPortal(ssid.c_str(), NULL);
+}
+
 boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPassword) {
   //setup AP
   WiFi.mode(WIFI_AP_STA);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -70,6 +70,7 @@ class WiFiManager
     boolean       autoConnect(char const *apName, char const *apPassword = NULL);
 
     //if you want to always start the config portal, without trying to connect first
+    boolean       startConfigPortal();
     boolean       startConfigPortal(char const *apName, char const *apPassword = NULL);
 
     // get the AP name of the config portal, so it can be used in the callback


### PR DESCRIPTION
Allows to use startConfigPortal() without parameters. In this case the AP uses auto generated name ESP + ChipID just like autoConnect().