### PR TITLE
Adding WiFiManagerParameter implementation with labelPlacement parameter

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -29,6 +29,10 @@ WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placehold
   init(id, placeholder, defaultValue, length, custom, WFM_LABEL_BEFORE);
 }
 
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length, const char *custom, int labelPlacement) {
+  init(id, placeholder, defaultValue, length, custom, labelPlacement);
+}
+
 void WiFiManagerParameter::init(const char *id, const char *placeholder, const char *defaultValue, int length, const char *custom, int labelPlacement) {
   _id = id;
   _placeholder = placeholder;


### PR DESCRIPTION
Without the suggested change, below error will occur during compilation (if parameter with custom "labelPlacement" was added): 

`undefined reference to WiFiManagerParameter::WiFiManagerParameter(char const*, char const*, char const*, int, char const*, int)`