### PR TITLE
use setAPStaticIPConfig instead  of (old?) setAPConfig in first example

### DIFF
--- a/examples/AutoConnect/AutoConnect.ino
+++ b/examples/AutoConnect/AutoConnect.ino
@@ -17,7 +17,7 @@ void setup() {
     //wifiManager.resetSettings();
     
     //set custom ip for portal
-    //wifiManager.setAPConfig(IPAddress(10,0,1,1), IPAddress(10,0,1,1), IPAddress(255,255,255,0));
+    //wifiManager.setAPStaticIPConfig(IPAddress(10,0,1,1), IPAddress(10,0,1,1), IPAddress(255,255,255,0));
 
     //fetches ssid and pass from eeprom and tries to connect
     //if it does not connect it starts an access point with the specified name


### PR DESCRIPTION
The (old?) function call is only done in a commented-out section, so the bug does not directly affect the functionality of the example code. But I encountered the error when I started playing with the various options of the WiFi Manager.  