### PR TITLE
Don't add custom parameters if array size is exceeded

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -64,6 +64,14 @@ WiFiManager::WiFiManager() {
 }
 
 void WiFiManager::addParameter(WiFiManagerParameter *p) {
+  if(_paramsCount + 1 > WIFI_MANAGER_MAX_PARAMS)
+  {
+    //Max parameters exceeded!
+	DEBUG_WM("WIFI_MANAGER_MAX_PARAMS exceeded, increase number (in WiFiManager.h) before adding more parameters!");
+	DEBUG_WM("Skipping parameter with ID:");
+	DEBUG_WM(p->getID());
+	return;
+  }
   _params[_paramsCount] = p;
   _paramsCount++;
   DEBUG_WM("Adding parameter");


### PR DESCRIPTION
array containing custom parameters is initialised at class
initialization time with a fixed value. When we later try to add more
parameters than the array allows we will now discard the offending
parameters and make a debug logging so the developer knows what's going
on.

Might be further improved as per this answer on StackOverflow:
http://stackoverflow.com/a/12271501
This would allow the array size to be specified at initialisation time,
and would give flexibility to the developer to decide how big the array
should be.

closes tzapu/WiFiManager#285