### PR TITLE
Allow showing static IP config without predefined value

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -500,7 +500,7 @@ void WiFiManager::handleWifi(boolean scan) {
     page += "<br/>";
   }
 
-  if (_sta_show_static_fields) {
+  if (_sta_show_static_fields || _sta_static_ip) {
 
     String item = FPSTR(HTTP_FORM_PARAM);
     item.replace("{i}", "ip");

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -131,14 +131,16 @@ void WiFiManager::setupConfigPortal() {
 
 }
 
-boolean WiFiManager::autoConnect() {
+boolean WiFiManager::autoConnect(boolean showStaticIPFields) {
   String ssid = "ESP" + String(ESP.getChipId());
-  return autoConnect(ssid.c_str(), NULL);
+  return autoConnect(ssid.c_str(), NULL, showStaticIPFields);
 }
 
-boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
+boolean WiFiManager::autoConnect(char const *apName, char const *apPassword, boolean showStaticIPFields) {
   DEBUG_WM(F(""));
   DEBUG_WM(F("AutoConnect"));
+
+  _sta_show_static_fields = showStaticIPFields;
 
   // read eeprom for ssid and pass
   //String ssid = getSSID();
@@ -498,14 +500,14 @@ void WiFiManager::handleWifi(boolean scan) {
     page += "<br/>";
   }
 
-  if (_sta_static_ip) {
+  if (_sta_show_static_fields) {
 
     String item = FPSTR(HTTP_FORM_PARAM);
     item.replace("{i}", "ip");
     item.replace("{n}", "ip");
     item.replace("{p}", "Static IP");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_ip.toString());
+    item.replace("{v}", (_sta_static_ip ? _sta_static_ip.toString() : ""));
 
     page += item;
 
@@ -514,7 +516,7 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "gw");
     item.replace("{p}", "Static Gateway");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_gw.toString());
+    item.replace("{v}", (_sta_static_gw ? _sta_static_gw.toString() : ""));
 
     page += item;
 
@@ -523,7 +525,7 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "sn");
     item.replace("{p}", "Subnet");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_sn.toString());
+    item.replace("{v}", (_sta_static_sn ? _sta_static_sn.toString() : ""));
 
     page += item;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -35,7 +35,7 @@ const char HTTP_SCAN_LINK[] PROGMEM       = "<br/><div class=\"c\"><a href=\"/wi
 const char HTTP_SAVED[] PROGMEM           = "<div>Credentials Saved<br />Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";
 const char HTTP_END[] PROGMEM             = "</div></body></html>";
 
-#define WIFI_MANAGER_MAX_PARAMS 10
+#define WIFI_MANAGER_MAX_PARAMS 20
 
 class WiFiManagerParameter {
   public:
@@ -66,8 +66,8 @@ class WiFiManager
   public:
     WiFiManager();
 
-    boolean       autoConnect();
-    boolean       autoConnect(char const *apName, char const *apPassword = NULL);
+    boolean       autoConnect(boolean showStaticIPFields = false);
+    boolean       autoConnect(char const *apName, char const *apPassword = NULL, boolean showStaticIPFields = false);
 
     //if you want to always start the config portal, without trying to connect first
     boolean       startConfigPortal();
@@ -136,6 +136,7 @@ class WiFiManager
     IPAddress     _sta_static_ip;
     IPAddress     _sta_static_gw;
     IPAddress     _sta_static_sn;
+    boolean       _sta_show_static_fields = false;
 
     int           _paramsCount            = 0;
     int           _minimumQuality         = -1;


### PR DESCRIPTION
Previously a valid predefined static IP had to be passed before the
config page would show the IP, gateway and subnet fields. This did not
allow the config page to show 'optional' static IP fields.
Now a boolean can be passed to the autoConnect() function which will
specify whether the static IP fields should be shown or not.
When this boolean is true but no predefined values are passed and fields
are left blank in config page, wifiManager will revert to DHCP. This
allows user to choose between static IP or DHCP without changing code

For backwards compatibility we will show the static IP fields regardless of how the boolean is set.