### PR TITLE
use malloc/free for WiFiManagerParameter* array instead of hard coding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,6 @@ You should also take a look at adding custom HTML to your form.
 - Save and load custom parameters to file system in json form [AutoConnectWithFSParameters](https://github.com/tzapu/WiFiManager/tree/master/examples/AutoConnectWithFSParameters)
 - *Save and load custom parameters to EEPROM* (not done yet)
 
-NOTE: if your need more than 10 (the default) custom parameters you will need to use the alternate constructor:
-```cpp
-WiFiManager wifiManager(15); // pass the number of params you will be adding
-```
-
 #### Custom IP Configuration
 You can set a custom IP for both AP (access point, config mode) and STA (station mode, client mode, normal project state)
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ You should also take a look at adding custom HTML to your form.
 - Save and load custom parameters to file system in json form [AutoConnectWithFSParameters](https://github.com/tzapu/WiFiManager/tree/master/examples/AutoConnectWithFSParameters)
 - *Save and load custom parameters to EEPROM* (not done yet)
 
+NOTE: if your need more than 10 (the default) custom parameters you will need to use the alternate constructor:
+```cpp
+WiFiManager wifiManager(15); // pass the number of params you will be adding
+```
+
 #### Custom IP Configuration
 You can set a custom IP for both AP (access point, config mode) and STA (station mode, client mode, normal project state)
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -61,10 +61,8 @@ const char* WiFiManagerParameter::getCustomHTML() {
 }
 
 
-WiFiManager::WiFiManager(int max_params) {
-    DEBUG_WM(F("setting max_params to:"));
-    DEBUG_WM(max_params);
-    _max_params = max_params;
+WiFiManager::WiFiManager() {
+    _max_params = WIFI_MANAGER_MAX_PARAMS;
     _params = (WiFiManagerParameter**)malloc(_max_params * sizeof(WiFiManagerParameter*));
 }
 
@@ -80,12 +78,17 @@ WiFiManager::~WiFiManager()
 void WiFiManager::addParameter(WiFiManagerParameter *p) {
   if(_paramsCount + 1 > _max_params)
   {
-    //Max parameters exceeded!
-	DEBUG_WM("max_params value exceeded, use WiFiManager(int max_params) constructor with a larger value!");
-	DEBUG_WM("Skipping parameter with ID:");
-	DEBUG_WM(p->getID());
-	return;
+    // rezise the params array
+    _max_params += WIFI_MANAGER_MAX_PARAMS;
+    DEBUG_WM(F("Increasing _max_params to:"));
+    DEBUG_WM(_max_params);
+    WiFiManagerParameter** new_params = (WiFiManagerParameter**)malloc(_max_params * sizeof(WiFiManagerParameter*));
+    // copy old data
+    memcpy(new_params, _params, _paramsCount * sizeof(WiFiManagerParameter*));
+    free(_params);
+    _params = new_params;
   }
+
   _params[_paramsCount] = p;
   _paramsCount++;
   DEBUG_WM("Adding parameter");

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -60,14 +60,37 @@ const char* WiFiManagerParameter::getCustomHTML() {
   return _customHTML;
 }
 
+
 WiFiManager::WiFiManager() {
+    init(WIFI_MANAGER_MAX_PARAMS);
+}
+
+WiFiManager::WiFiManager(int max_params) {
+    init(max_params);
+}
+
+void WiFiManager::init(int max_params)
+{
+    DEBUG_WM(F("setting max_params to:"));
+    DEBUG_WM(max_params);
+    _max_params = max_params;
+    _params = (WiFiManagerParameter**)malloc(_max_params * sizeof(WiFiManagerParameter*));
+}
+
+WiFiManager::~WiFiManager()
+{
+    if (_params != NULL)
+    {
+        DEBUG_WM(F("freeing allocated params!"));
+        free(_params);
+    }
 }
 
 void WiFiManager::addParameter(WiFiManagerParameter *p) {
-  if(_paramsCount + 1 > WIFI_MANAGER_MAX_PARAMS)
+  if(_paramsCount + 1 > _max_params)
   {
     //Max parameters exceeded!
-	DEBUG_WM("WIFI_MANAGER_MAX_PARAMS exceeded, increase number (in WiFiManager.h) before adding more parameters!");
+	DEBUG_WM("max_params value exceeded, use WiFiManager(int max_params) constructor with a larger value!");
 	DEBUG_WM("Skipping parameter with ID:");
 	DEBUG_WM(p->getID());
 	return;

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -62,11 +62,6 @@ const char* WiFiManagerParameter::getCustomHTML() {
 
 
 WiFiManager::WiFiManager(int max_params) {
-    init(max_params);
-}
-
-void WiFiManager::init(int max_params)
-{
     DEBUG_WM(F("setting max_params to:"));
     DEBUG_WM(max_params);
     _max_params = max_params;

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -61,10 +61,6 @@ const char* WiFiManagerParameter::getCustomHTML() {
 }
 
 
-WiFiManager::WiFiManager() {
-    init(WIFI_MANAGER_MAX_PARAMS);
-}
-
 WiFiManager::WiFiManager(int max_params) {
     init(max_params);
 }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -75,24 +75,27 @@ WiFiManager::~WiFiManager()
     }
 }
 
-void WiFiManager::addParameter(WiFiManagerParameter *p) {
+bool WiFiManager::addParameter(WiFiManagerParameter *p) {
   if(_paramsCount + 1 > _max_params)
   {
     // rezise the params array
     _max_params += WIFI_MANAGER_MAX_PARAMS;
     DEBUG_WM(F("Increasing _max_params to:"));
     DEBUG_WM(_max_params);
-    WiFiManagerParameter** new_params = (WiFiManagerParameter**)malloc(_max_params * sizeof(WiFiManagerParameter*));
-    // copy old data
-    memcpy(new_params, _params, _paramsCount * sizeof(WiFiManagerParameter*));
-    free(_params);
-    _params = new_params;
+    WiFiManagerParameter** new_params = (WiFiManagerParameter**)realloc(_params, _max_params * sizeof(WiFiManagerParameter*));
+    if (new_params != NULL) {
+      _params = new_params;
+    } else {
+      DEBUG_WM("ERROR: failed to realloc params, size not increased!");
+      return false;
+    }
   }
 
   _params[_paramsCount] = p;
   _paramsCount++;
   DEBUG_WM("Adding parameter");
   DEBUG_WM(p->getID());
+  return true;
 }
 
 void WiFiManager::setupConfigPortal() {

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -65,6 +65,8 @@ class WiFiManager
 {
   public:
     WiFiManager();
+    WiFiManager(int max_params);
+    ~WiFiManager();
 
     boolean       autoConnect();
     boolean       autoConnect(char const *apName, char const *apPassword = NULL);
@@ -119,6 +121,7 @@ class WiFiManager
 
     //const String  HTTP_HEAD = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/><title>{v}</title>";
 
+    void          init(int max_params);
     void          setupConfigPortal();
     void          startWPS();
 
@@ -176,7 +179,8 @@ class WiFiManager
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
 
-    WiFiManagerParameter* _params[WIFI_MANAGER_MAX_PARAMS];
+    int                    _max_params;
+    WiFiManagerParameter** _params;
 
     template <typename Generic>
     void          DEBUG_WM(Generic text);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -64,7 +64,7 @@ class WiFiManagerParameter {
 class WiFiManager
 {
   public:
-    WiFiManager(int max_params=10);
+    WiFiManager();
     ~WiFiManager();
 
     boolean       autoConnect();

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -64,7 +64,6 @@ class WiFiManagerParameter {
 class WiFiManager
 {
   public:
-    WiFiManager();
     WiFiManager(int max_params=10);
     ~WiFiManager();
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -100,8 +100,8 @@ class WiFiManager
     void          setAPCallback( void (*func)(WiFiManager*) );
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
-    //adds a custom parameter
-    void          addParameter(WiFiManagerParameter *p);
+    //adds a custom parameter, returns false on failure
+    bool          addParameter(WiFiManagerParameter *p);
     //if this is set, it will exit after config, even if connection is unsuccessful.
     void          setBreakAfterConfig(boolean shouldBreak);
     //if this is set, try WPS setup when starting (this will delay config portal for up to 2 mins)

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -121,7 +121,6 @@ class WiFiManager
 
     //const String  HTTP_HEAD = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/><title>{v}</title>";
 
-    void          init(int max_params);
     void          setupConfigPortal();
     void          startWPS();
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -65,7 +65,7 @@ class WiFiManager
 {
   public:
     WiFiManager();
-    WiFiManager(int max_params);
+    WiFiManager(int max_params=10);
     ~WiFiManager();
 
     boolean       autoConnect();


### PR DESCRIPTION
   Dynamically allocate the _params array.  Existing no arg constructor uses the same default, 10, as it used to.  Added a second constructor that allows setting size.  Added Destructor that frees allocated _params.
