### PR TITLE
Add bool autoConnect() function

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -157,6 +157,23 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
   return startConfigPortal(apName, apPassword);
 }
 
+boolean WiFiManager::ConnectWifi(){
+    DEBUG_WM(F(""));
+    DEBUG_WM(F("Attempt to Connect Wifi"));
+
+    // attempt to connect;
+    WiFi.mode(WIFI_STA);
+
+    if (connectWifi("", "") == WL_CONNECTED)   {
+      DEBUG_WM(F("IP Address:"));
+      DEBUG_WM(WiFi.localIP());
+      //connected
+      return true;
+    }
+
+    return false;
+}
+
 boolean WiFiManager::configPortalHasTimeout(){
     if(_configPortalTimeout == 0 || wifi_softap_get_station_num() > 0){
       _configPortalStart = millis(); // kludge, bump configportal start time to skew timeouts

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -68,7 +68,10 @@ class WiFiManager
 
     boolean       autoConnect();
     boolean       autoConnect(char const *apName, char const *apPassword = NULL);
-
+    
+   //Attemp to connect wifi, return true if success
+    boolean       ConnectWifi();
+   
     //if you want to always start the config portal, without trying to connect first
     boolean       startConfigPortal();
     boolean       startConfigPortal(char const *apName, char const *apPassword = NULL);


### PR DESCRIPTION
Although autoConnect() can directly connect wifi, but it turns into AP mode right away if it can not connect to the wifi.
And this will be super limited to users. In some cases, for example, user want to know if they can connect to wifi, and go for sleep   ##after several attempts and avoid directly entering AP mode. Only enter AP mode by some hard reset, which can increase the network security when power outage happened with device/network.