### PR TITLE
Add custom_saved_elemend to customize HTTP_SAVED block

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -603,7 +603,7 @@ void WiFiManager::handleWifiSave() {
   page += FPSTR(HTTP_STYLE);
   page += _customHeadElement;
   page += FPSTR(HTTP_HEAD_END);
-  page += FPSTR(HTTP_SAVED);
+  page += _customSavedElement;
   page += FPSTR(HTTP_END);
 
   server->sendHeader("Content-Length", String(page.length()));
@@ -726,6 +726,10 @@ void WiFiManager::setSaveConfigCallback( void (*func)(void) ) {
 //sets a custom element to add to head, like a new style tag
 void WiFiManager::setCustomHeadElement(const char* element) {
   _customHeadElement = element;
+}
+
+void WiFiManager::setCustomSavedElement(const char* element) {
+  _customSavedElement = element;
 }
 
 //if this is true, remove duplicated Access Points - defaut true

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -107,6 +107,7 @@ class WiFiManager
     //TODO
     //if this is set, customise style
     void          setCustomHeadElement(const char* element);
+    void          setCustomSavedElement(const char* element);
     //if this is true, remove duplicated Access Points - defaut true
     void          setRemoveDuplicateAPs(boolean removeDuplicates);
 
@@ -144,6 +145,7 @@ class WiFiManager
     boolean       _tryWPS                 = false;
 
     const char*   _customHeadElement      = "";
+    const char*   _customSavedElement     = "<div>Credentials Saved<br />Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";
 
     //String        getEEPROMString(int start, int len);
     //void          setEEPROMString(int start, int len, String string);


### PR DESCRIPTION
Hi everyone!
A few days ago I got a little task to do a more detailed instruction for users what to do with esp8266 at HTTP_SAVED html block. So I decided to make a function like setCustomHeadElement for it. 

Please tell me how can I make it more elegant way? :) Otherwise I think this little commit would be useful for somebody.