### PR TITLE
added conditional definition to PROGMEM strings for easy override

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -22,6 +22,13 @@ extern "C" {
   #include "user_interface.h"
 }
 
+#ifndef WIFI_MANAGER_OVERRIDE_STRINGS
+
+// To override the strings below in your project, make the following changes above the line that includes "WiFIManager.h"
+// Add the following line:
+//   #define WIFI_MANAGER_OVERRIDE_STRINGS
+// Copy and paste ALL of the const char lines below and modify to suit.
+
 const char HTTP_HEAD[] PROGMEM            = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/><title>{v}</title>";
 const char HTTP_STYLE[] PROGMEM           = "<style>.c{text-align: center;} div,input{padding:5px;font-size:1em;} input{width:95%;} body{text-align: center;font-family:verdana;} button{border:0;border-radius:0.3rem;background-color:#1fa3ec;color:#fff;line-height:2.4rem;font-size:1.2rem;width:100%;} .q{float: right;width: 64px;text-align: right;} .l{background: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAALVBMVEX///8EBwfBwsLw8PAzNjaCg4NTVVUjJiZDRUUUFxdiZGSho6OSk5Pg4eFydHTCjaf3AAAAZElEQVQ4je2NSw7AIAhEBamKn97/uMXEGBvozkWb9C2Zx4xzWykBhFAeYp9gkLyZE0zIMno9n4g19hmdY39scwqVkOXaxph0ZCXQcqxSpgQpONa59wkRDOL93eAXvimwlbPbwwVAegLS1HGfZAAAAABJRU5ErkJggg==\") no-repeat left center;background-size: 1em;}</style>";
 const char HTTP_SCRIPT[] PROGMEM          = "<script>function c(l){document.getElementById('s').value=l.innerText||l.textContent;document.getElementById('p').focus();}</script>";
@@ -34,6 +41,10 @@ const char HTTP_FORM_END[] PROGMEM        = "<br/><button type='submit'>save</bu
 const char HTTP_SCAN_LINK[] PROGMEM       = "<br/><div class=\"c\"><a href=\"/wifi\">Scan</a></div>";
 const char HTTP_SAVED[] PROGMEM           = "<div>Credentials Saved<br />Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";
 const char HTTP_END[] PROGMEM             = "</div></body></html>";
+
+// Stop copy/paste here
+
+#endif
 
 #define WIFI_MANAGER_MAX_PARAMS 10
 


### PR DESCRIPTION
I've added an #ifndef statement to make definition of the PROGMEM strings easier to override.  The LaserWeb3 web socket server project wanted me to modify the library files directly, making it unusable for other projects.  This makes it universal.  Documentation is included in the header file.