### PR TITLE
Connection Initialization Fixes

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -196,7 +196,17 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     //HTTP
     server->handleClient();
 
-
+	  //added to solve the problem of power cut -> keep trying to connect using last saved values edit#1
+	  
+	if (WiFi.status() == WL_CONNECTED){
+	WiFi.mode(WIFI_STA);
+	DEBUG_WM(F("connected with last saved values, AP will be closed"));
+	DEBUG_WM(F("IP Address:"));
+        DEBUG_WM(WiFi.localIP());
+        break;
+	}
+	 //edit#1
+	  
     if (connect) {
       connect = false;
       delay(2000);
@@ -253,6 +263,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
   //check if we have ssid and pass and force those, if not, try with last saved values
   if (ssid != "") {
     WiFi.begin(ssid.c_str(), pass.c_str());
+	delay(1000);  //To solve the problem of connected but still waiting for the ssid and password in the same time edit#2
   } else {
     if (WiFi.SSID()) {
       DEBUG_WM("Using last saved values, should be faster");
@@ -262,6 +273,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
       ETS_UART_INTR_ENABLE();
 
       WiFi.begin();
+delay(1000); //To solve the problem of connected but still waiting for the ssid and password in the same time edit#3
     } else {
       DEBUG_WM("No saved credentials");
     }
@@ -317,7 +329,6 @@ void WiFiManager::startWPS() {
   }
   return _ssid;
   }
-
   String WiFiManager::getPassword() {
   if (_pass == "") {
     DEBUG_WM(F("Reading Password"));


### PR DESCRIPTION
To solve the problem occurs after a power cut (WiFi router takes a while to broadcast a WiFi network, so esp8266 searches for the saved network but of course it will not be found, so switches to ap_sta mode and wait for an external config via the captive portal) -> solved by  making the esp8266 keep trying to connect using last saved values even if it is not found at the start of autoConnect() and if it connected get out of autoConnect()  Edit#1

To solve the problem of connected but still waiting for the ssid and password in the same time edit#2,3