### PR TITLE
Document that parameter id cannot contain spaces

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -39,6 +39,10 @@ const char HTTP_END[] PROGMEM             = "</div></body></html>";
 
 class WiFiManagerParameter {
   public:
+    /** 
+        Create custom parameters that can be added to the WiFiManager setup web page
+        @id is used for HTTP queries and must not contain spaces nor other special characters
+    */
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length);
     WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length, const char *custom);


### PR DESCRIPTION
It took me a while to figure out that custom parameters don't work if there is a space in the id parameter. It's not particularly useful to make this work, so just document that it doesn't.

The reason it doesn't work: the client will use the id parameter as the name of the field in the HTTP GET request that goes back to the server. Spaces and other special characters will get encoded, so "Blynk token" becomes "Blynk+token". The server doesn't do any kind of decoding so it gets confused and thinks the parameter just isn't there.