### PR TITLE
WiFiManagerParameter allocates but never frees __value!

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -44,6 +44,12 @@ void WiFiManagerParameter::init(const char *id, const char *placeholder, const c
   _customHTML = custom;
 }
 
+WiFiManagerParameter::~WiFiManagerParameter() {
+  if (_value != NULL) {
+    delete _value;
+  }
+}
+
 const char* WiFiManagerParameter::getValue() {
   return _value;
 }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -46,7 +46,7 @@ void WiFiManagerParameter::init(const char *id, const char *placeholder, const c
 
 WiFiManagerParameter::~WiFiManagerParameter() {
   if (_value != NULL) {
-    delete _value;
+    delete[] _value;
   }
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -42,6 +42,7 @@ class WiFiManagerParameter {
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length);
     WiFiManagerParameter(const char *id, const char *placeholder, const char *defaultValue, int length, const char *custom);
+    ~WiFiManagerParameter();
 
     const char *getID();
     const char *getValue();


### PR DESCRIPTION
The WiFiManagerParameter constructor allocates _value via new but has no destructor to free  via delete.