### PR TITLE
Do not bail when attempting to change SSID (fixes #336)

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -246,7 +246,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
     DEBUG_WM(WiFi.localIP());
   }
   //fix for auto connect racing issue
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED && (WiFi.SSID() == ssid)) {
     DEBUG_WM("Already connected. Bailing out.");
     return WL_CONNECTED;
   }


### PR DESCRIPTION
This change avoids "Bailing out" when we are attempting to a connect to a new network but are already connected to a previous one.

This is the fix suggested by @babitsky in #336 and I have tested it successfully.