### PR TITLE
make WIFI_MANAGER_MAX_PARAMS customizable

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -35,7 +35,9 @@ const char HTTP_SCAN_LINK[] PROGMEM       = "<br/><div class=\"c\"><a href=\"/wi
 const char HTTP_SAVED[] PROGMEM           = "<div>Credentials Saved<br />Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";
 const char HTTP_END[] PROGMEM             = "</div></body></html>";
 
+#ifndef WIFI_MANAGER_MAX_PARAMS
 #define WIFI_MANAGER_MAX_PARAMS 10
+#endif
 
 class WiFiManagerParameter {
   public:


### PR DESCRIPTION
I think it's pretty useful to have this parameter customizable so that users can change it from outside if required (e.g platformio, make, etc). 

For example when using platformio I can set this in platformio.ini: 
**build_flags = -DWIFI_MANAGER_MAX_PARAMS=20**

This allows me to change  the value at compile time without modifying the library source code. I also provided the default value for it when not defined outside or somewhere else - you can see  that in the code changes that I want to propose.

This approach can be used for other defines in this library source code if desired/required.

Very nice work btw regarding this library - very useful. Thanks.