### PR TITLE
Bug fix for problem discovered when setting length to 1 for additiona…

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -34,7 +34,7 @@ void WiFiManagerParameter::init(const char *id, const char *placeholder, const c
   _placeholder = placeholder;
   _length = length;
   _value = new char[length + 1];
-  for (int i = 0; i < length; i++) {
+  for (int i = 0; i < length + 1; i++) {
     _value[i] = 0;
   }
   if (defaultValue != NULL) {
@@ -597,7 +597,7 @@ void WiFiManager::handleWifiSave() {
     //read parameter
     String value = server->arg(_params[i]->getID()).c_str();
     //store it in array
-    value.toCharArray(_params[i]->_value, _params[i]->_length);
+    value.toCharArray(_params[i]->_value, _params[i]->_length + 1);
     DEBUG_WM(F("Parameter"));
     DEBUG_WM(_params[i]->getID());
     DEBUG_WM(value);


### PR DESCRIPTION
…l parameters

The initialization of the buffer holding the value stopped before the last character and storage did not take into account the extra-byte for end of string.

Bug is pretty easy to reproduce : try to use an additional parameter with a length of 1. This PR fixes it.