### PR TITLE
Callback during wifi setup loop (for example, to flash an LED)

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -764,7 +764,7 @@ void WiFiManager::setRemoveDuplicateAPs(boolean removeDuplicates) {
 }
 
 //callback in loop during the setup phase, to allow for third party execution during setup wait
-void setSetupLoopCallback(void (*func)(void)) {
+void WiFiManager::setSetupLoopCallback(void (*func)(void)) {
   _setupLoopCallback = func;
 }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -252,6 +252,10 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
         break;
       }
     }
+
+    // give some time to the caller if they have asked for it
+    if (_setupLoopCallback)
+      _setupLoopCallback();
     yield();
   }
 
@@ -757,6 +761,11 @@ void WiFiManager::setCustomHeadElement(const char* element) {
 //if this is true, remove duplicated Access Points - defaut true
 void WiFiManager::setRemoveDuplicateAPs(boolean removeDuplicates) {
   _removeDuplicateAPs = removeDuplicates;
+}
+
+//callback in loop during the setup phase, to allow for third party execution during setup wait
+void setSetupLoopCallback(void (*func)(void)) {
+  _setupLoopCallback = func;
 }
 
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -117,6 +117,8 @@ class WiFiManager
     void          setCustomHeadElement(const char* element);
     //if this is true, remove duplicated Access Points - defaut true
     void          setRemoveDuplicateAPs(boolean removeDuplicates);
+    //callback in loop during the setup phase, to allow for third party execution during setup wait
+    void          setSetupLoopCallback(void (*func)(void));
 
   private:
     std::unique_ptr<DNSServer>        dnsServer;
@@ -152,6 +154,8 @@ class WiFiManager
     boolean       _tryWPS                 = false;
 
     const char*   _customHeadElement      = "";
+
+    void          (*_setupLoopCallback)(void) = null;
 
     //String        getEEPROMString(int start, int len);
     //void          setEEPROMString(int start, int len, String string);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -155,7 +155,7 @@ class WiFiManager
 
     const char*   _customHeadElement      = "";
 
-    void          (*_setupLoopCallback)(void) = null;
+    void          (*_setupLoopCallback)(void) = NULL;
 
     //String        getEEPROMString(int start, int len);
     //void          setEEPROMString(int start, int len, String string);


### PR DESCRIPTION
This very small patch enables a new feature to provide for an optional callback during the wifi config.  It is optional, so non-disruptive to existing implementations.  If setSetupLoopCallback is passed a function, that function will be called prior to yield() inside startConfigPortal.  We use this to "fast flash" an LED to indicate (pin 2 on the NODEMCU) to indicate that the device is pending configuration, rather than in operational mode.