### PR TITLE
allow automatic config portal to be disabled

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -259,6 +259,12 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
     }
     return true;
   }
+
+  // possibly skip the config portal
+  if (!_enableConfigPortal) {
+    return false;
+  }
+
   // not connected start configportal
   return startConfigPortal(apName, apPassword);
 }
@@ -1930,6 +1936,19 @@ void WiFiManager::setWebPortalClientCheck(boolean enabled){
 void WiFiManager::setScanDispPerc(boolean enabled){
   _scanDispOptions = enabled;
 }
+
+/**
+ * toggle configportal if autoconnect failed
+ * if enabled, then the configportal will be activated on autoconnect failure
+ * @since $dev
+ * @access public
+ * @param boolean enabled [true]
+ */
+void WiFiManager::setEnableConfigPortal(boolean enable)
+{
+    _enableConfigPortal = enable;
+}
+
 
 /**
  * set the hostname (dhcp client id)

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -204,6 +204,8 @@ class WiFiManager
     void          setWiFiAutoReconnect(boolean enabled);
     // if true, wifiscan will show percentage instead of quality icons, until we have better templating
     void          setScanDispPerc(boolean enabled);
+    // if true (default) then start the config portal from autoConnect if connection failed
+    void          setEnableConfigPortal(boolean enable);
     // set a custom hostname, sets sta and ap dhcp client id for esp32, and sta for esp8266
     bool          setHostname(const char * hostname);
     // show erase wifi onfig button on info page, true
@@ -292,6 +294,7 @@ class WiFiManager
     boolean       _scanDispOptions        = false; // show percentage in scans not icons
     boolean       _paramsInWifi           = true;  // show custom parameters on wifi page
     boolean       _showInfoErase          = true;  // info page erase button
+    boolean       _enableConfigPortal     = true;  // use config portal if autoconnect failed
     const char *  _hostname               = "";
 
     const char*   _customHeadElement      = ""; // store custom head element html from user


### PR DESCRIPTION
add setEnableConfigPortal(boolean enable) - if false don't open config portal from autoConnect()

PR for this issue: https://github.com/tzapu/WiFiManager/issues/574
