### PR TITLE
Changed setAPCallback and setSaveConfigCallback to take std::function…

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1809,17 +1809,17 @@ void WiFiManager::setBreakAfterConfig(boolean shouldBreak) {
  * @access public 
  * @param {[type]} void (*func)(WiFiManager* myWiFiManager) [description]
  */
-void WiFiManager::setAPCallback( void (*func)(WiFiManager* myWiFiManager) ) {
+void WiFiManager::setAPCallback( std::function<void(WiFiManager*)> func ) {
   _apcallback = func;
 }
-
+	
 /**
  * setSaveConfigCallback, set a save config callback after closing configportal
  * @todo only calls if configportal stopped
  * @access public
  * @param {[type]} void (*func)(void) [description]
  */
-void WiFiManager::setSaveConfigCallback( void (*func)(void) ) {
+void WiFiManager::setSaveConfigCallback( std::function<void()> func ) {
   _savecallback = func;
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -177,9 +177,9 @@ class WiFiManager
     //sets config for a static IP with DNS
     void          setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn, IPAddress dns);
     //called when AP mode and config portal is started
-    void          setAPCallback( void (*func)(WiFiManager*) );
+    void          setAPCallback( std::function<void(WiFiManager*)> func );
     //called when settings have been changed and connection was successful
-    void          setSaveConfigCallback( void (*func)(void) );
+    void          setSaveConfigCallback( std::function<void()> func );
     //adds a custom parameter, returns false on failure
     bool          addParameter(WiFiManagerParameter *p);
     //if this is set, it will exit after config, even if connection is unsuccessful.
@@ -418,8 +418,8 @@ class WiFiManager
     void        DEBUG_WM(wm_debuglevel_t level, Generic text,Genericb textb);
 
     // callbacks
-    void (*_apcallback)(WiFiManager*) = NULL;
-    void (*_savecallback)(void)       = NULL;
+    std::function<void(WiFiManager*)> _apcallback;
+    std::function<void()> _savecallback;
 
     template <class T>
     auto optionalIPFromString(T *obj, const char *s) -> decltype(  obj->fromString(s)  ) {


### PR DESCRIPTION
… params

This allows Predicates and Lambdas to be passed. Still allows bare function pointers
so this patch is fully backward compatible. Tested on WiFiManager examples for
backward compatibility and on my own project (OfficeClock) for handling lambdas with
captured variables