### PR TITLE
Wifi Wait Callback

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -742,7 +742,7 @@ boolean WiFiManager::captivePortal() {
   return false;
 }
 
-void WifiManager::setWifiWaitCallback( void (*func)(void) ) {
+void WiFiManager::setWifiWaitCallback( void (*func)(void) ) {
   _wifiWaitCallback = func;
 }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -742,7 +742,7 @@ boolean WiFiManager::captivePortal() {
   return false;
 }
 
-void WifiManager::setWifiWaitCallback( void (*func) WifiManager* myWifiManager) ) {
+void WifiManager::setWifiWaitCallback( void (*func)(void) ) {
   _wifiWaitCallback = func;
 }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -217,6 +217,10 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     // check if timeout
     if(configPortalHasTimeout()) break;
 
+    if (_wifiWaitCallback) {
+      _wifiWaitCallback();
+    }
+
     //DNS
     dnsServer->processNextRequest();
     //HTTP
@@ -249,10 +253,6 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
           _savecallback();
         }
         break;
-      }
-    } else {
-      if (_wifiWaitCallback) {
-        _wifiWaitCallback();
       }
     }
     yield();

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -222,7 +222,6 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     //HTTP
     server->handleClient();
 
-
     if (connect) {
       connect = false;
       delay(2000);
@@ -250,6 +249,10 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
           _savecallback();
         }
         break;
+      }
+    } else {
+      if (_wifiWaitCallback) {
+        _wifiWaitCallback();
       }
     }
     yield();
@@ -737,6 +740,10 @@ boolean WiFiManager::captivePortal() {
     return true;
   }
   return false;
+}
+
+void WifiManager::setWifiWaitCallback( void (*func) WifiManager* myWifiManager) ) {
+  _wifiWaitCallback = func;
 }
 
 //start up config portal callback

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -217,8 +217,8 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     // check if timeout
     if(configPortalHasTimeout()) break;
 
-    if (_wifiWaitCallback) {
-      _wifiWaitCallback();
+    if (_wifiWaitCallback && _wifiWaitCallback()) {
+      break;
     }
 
     //DNS
@@ -742,7 +742,7 @@ boolean WiFiManager::captivePortal() {
   return false;
 }
 
-void WiFiManager::setWifiWaitCallback( void (*func)(void) ) {
+void WiFiManager::setWifiWaitCallback( bool (*func)(void) ) {
   _wifiWaitCallback = func;
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -108,7 +108,7 @@ class WiFiManager
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
     // called when waiting around for wifi
-    void          setWifiWaitCallback( void (*func)(void) );
+    void          setWifiWaitCallback( bool (*func)(void) );
     //adds a custom parameter, returns false on failure
     bool          addParameter(WiFiManagerParameter *p);
     //if this is set, it will exit after config, even if connection is unsuccessful.
@@ -183,7 +183,7 @@ class WiFiManager
     boolean       connect;
     boolean       _debug = true;
 
-    void (*_wifiWaitCallback)(void) = NULL;
+    bool (*_wifiWaitCallback)(void) = NULL;
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -41,7 +41,7 @@ const char HTTP_END[] PROGMEM             = "</div></body></html>";
 
 class WiFiManagerParameter {
   public:
-    /** 
+    /**
         Create custom parameters that can be added to the WiFiManager setup web page
         @id is used for HTTP queries and must not contain spaces nor other special characters
     */
@@ -181,6 +181,7 @@ class WiFiManager
     boolean       connect;
     boolean       _debug = true;
 
+    void (*_wifiWaitCallback)(WiFiManager*) = NULL;
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -183,7 +183,7 @@ class WiFiManager
     boolean       connect;
     boolean       _debug = true;
 
-    void (*_wifiWaitCallback)(WiFiManager*) = NULL;
+    void (*_wifiWaitCallback)(void) = NULL;
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -107,6 +107,8 @@ class WiFiManager
     void          setAPCallback( void (*func)(WiFiManager*) );
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
+    // called when waiting around for wifi
+    void          setWifiWaitCallback( void (*func)(void) );
     //adds a custom parameter, returns false on failure
     bool          addParameter(WiFiManagerParameter *p);
     //if this is set, it will exit after config, even if connection is unsuccessful.


### PR DESCRIPTION
When WifiManger is running the config portal, we currently don't have any control and can't make anything happen. We'd like to do some fun things to indicate current status, as well as escape the Wifi configuration step if we need to run offline. This change introduces a `wifiWaitCallback` that gets called every WiFi config portal loop.