### PR TITLE
Fixing pointer causes repeated memory leaks

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -78,6 +78,7 @@ WiFiManager::~WiFiManager()
     {
         DEBUG_WM(F("freeing allocated params!"));
         free(_params);
+		_params = NULL;
     }
 }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -78,7 +78,7 @@ WiFiManager::~WiFiManager()
     {
         DEBUG_WM(F("freeing allocated params!"));
         free(_params);
-		_params = NULL;
+        _params = NULL;
     }
 }
 


### PR DESCRIPTION
Repairing duplicate calls causes memory leaks