### PR TITLE
Fixed: Waiting for connection result with time out issue

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -319,7 +319,7 @@ uint8_t WiFiManager::waitForConnectResult() {
         keepConnecting = false;
         DEBUG_WM (F("Connection timed out"));
       }
-      if (status == WL_CONNECTED || status == WL_CONNECT_FAILED) {
+      if (status == WL_CONNECTED) {
         keepConnecting = false;
       }
       delay(100);


### PR DESCRIPTION
Fixed Waiting for connection result with time out issue.

If the ESP connection to wifi network on first try was unsuccess, there was no another try regardless timeout is how far away. This modification fixes the issue.