### PR TITLE
multiple network support (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ First attempt at a library. Lots more changes and fixes to do. Contributions are
 - [x] maybe allow setting ip of ESP after reboot
 - [x] add to Arduino Library Manager
 - [x] add to PlatformIO
-- [ ] add multiple sets of network credentials
+- [x] add multiple sets of network credentials
 - [x] allow users to customize CSS
 - [ ] ESP32 support or instructions
 - [ ] rewrite documentation for simplicity, based on scenarios/goals
@@ -200,6 +200,26 @@ Normally, once entered, the configuration portal will continue to loop until WiF
 If you'd prefer to exit without joining a WiFi network, say becuase you're going to put the ESP into AP mode, then press the "Exit" button
 on the main webpage.
 If started via `autoConnect` or `startConfigPortal` then it will return `false (portalAbortResult)`
+
+#### Multiple Networks
+You can add known networks and their credentials. WiFiManager will try to connect to the last network the ESP was connected to. If this fails, it will connect to the strongest network in your network list.
+```cpp
+wifiManager.addAP("myAP", "myPassword");
+wifiManager.addAP("guest"); // or without password
+```
+
+You can get the saved SSIDs and passwords for a network in the list with ` wifiManager.getAP(index)`. This will return a pointer to the network data, or NULL is the index is not valid (e.g. list is smaller than index).
+
+When you connect to a new access point, it will automatically be added to the list of known networks. This can be used to dynamically build a list of all your networks.
+**However, you are responsible for saving and loading these custom values.**
+
+Example usage: printing all known networks after connection
+```cpp
+for (int i = 0; auto ap = wifiManager.getAP(i); i++ )
+  Serial.println(ap->ssid + ", " + ap->pass);
+```
+See the *AutoConnectMultipleNetworks* example.
+
 
 #### Custom Parameters
 You can use WiFiManager to collect more parameters than just SSID and password.

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -666,6 +666,11 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass) {
   if (ssid != "" && connRes == WL_CONNECTED ) {
     // add to known APs
     addAP(ssid.c_str(), pass.c_str());
+    // notify application about adding a new network
+    if ( _savecallback != NULL) {
+       _savecallback();
+    }
+
   }
 
   // do WPS, if WPS options enabled and not connected and no password was supplied

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -343,6 +343,7 @@ class WiFiManager
     void          handleWifiSave();
     void          handleInfo();
     void          handleReset();
+	void          handleDelete();
     void          handleNotFound();
     void          handleExit();
     void          handleClose();

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -82,6 +82,9 @@
 #ifndef WIFI_MANAGER_MAX_PARAMS
     #define WIFI_MANAGER_MAX_PARAMS 5 // params will autoincrement and realloc by this amount when max is reached
 #endif
+#ifndef WIFI_MANAGER_MAX_NETWORKS
+    #define WIFI_MANAGER_MAX_NETWORKS 5 // maximal number of network credentials to be stored
+#endif
 
 #define WFM_LABEL_BEFORE 1
 #define WFM_LABEL_AFTER 2
@@ -121,6 +124,10 @@ class WiFiManagerParameter {
     friend class WiFiManager;
 };
 
+struct WiFiManagerCredentials {
+  String ssid;
+  String pass;
+};
 
 class WiFiManager
 {
@@ -145,6 +152,13 @@ class WiFiManager
     // Run webserver processing, if setConfigPortalBlocking(false)
     boolean       process();
 
+    //add an AP to the list of known access points to be connected to
+    boolean       addAP(char const *ssid, char const *password = NULL);
+	  //returns the SSID and password for a pre-configured access point
+    //or NULL if no access point was found for the given index
+    //the returned values are read-only!
+	const WiFiManagerCredentials *getAP(uint8_t index) const;
+	
     // get the AP name of the config portal, so it can be used in the callback
     String        getConfigPortalSSID();
 
@@ -409,6 +423,9 @@ class WiFiManager
     boolean       _debug              = true;
     uint8_t       _debugLevel         = DEBUG_VERBOSE;
     Stream&     _debugPort; // debug output stream ref
+    
+    uint8_t       _apList_size = 0;
+    WiFiManagerCredentials _apList[WIFI_MANAGER_MAX_NETWORKS];
     
     template <typename Generic>
     void        DEBUG_WM(Generic text);

--- a/examples/AutoConnectMultipleNetworks/AutoConnectMultipleNetworks.ino
+++ b/examples/AutoConnectMultipleNetworks/AutoConnectMultipleNetworks.ino
@@ -1,0 +1,50 @@
+#include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
+
+//needed for library
+#include <DNSServer.h>
+#include <ESP8266WebServer.h>
+#include "WiFiManager.h"          //https://github.com/tzapu/WiFiManager
+
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  
+  //WiFiManager
+  //Local intialization. Once its business is done, there is no need to keep it around
+  WiFiManager wifiManager;
+  //reset settings - for testing
+  wifiManager.resetSettings();
+
+  // add known access point credentials
+  // these settings will be used if the connection to the last connected network fails
+  wifiManager.addAP("myAP", "myPassword");
+  wifiManager.addAP("guest"); // or without password
+
+
+  //fetches ssid and pass and tries to connect
+  //if it does not connect it starts an access point with the specified name
+  //here  "AutoConnectAP"
+  //and goes into a blocking loop awaiting configuration
+  if(!wifiManager.autoConnect()) {
+    Serial.println("failed to connect and hit timeout");
+    //reset and try again, or maybe put it to deep sleep
+    ESP.reset();
+    delay(1000);
+  } 
+
+  //if you get here you have connected to the WiFi
+  Serial.print("connected to: "); Serial.println(WiFi.SSID());
+  Serial.print("local ip: "); Serial.println(WiFi.localIP());
+
+  // display all known access points
+  Serial.println("saved access points:");
+  for (int i = 0; auto ap = wifiManager.getAP(i); i++ ) {
+    Serial.println("  " + ap->ssid + ", " + ap->pass);
+  }
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+}

--- a/examples/AutoConnectMultipleNetworksWithFS/AutoConnectMultipleNetworksWithFS.ino
+++ b/examples/AutoConnectMultipleNetworksWithFS/AutoConnectMultipleNetworksWithFS.ino
@@ -1,0 +1,133 @@
+#include <FS.h>                   //this needs to be first, or it all crashes and burns...
+#include <ArduinoJson.h>          //https://github.com/bblanchon/ArduinoJson
+
+#include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
+
+//needed for library
+#include <DNSServer.h>
+#include <ESP8266WebServer.h>
+#include "WiFiManager.h"          //https://github.com/tzapu/WiFiManager
+
+
+void load(WiFiManager &wifiManager) {
+  //clean FS, for testing
+//  SPIFFS.format();
+
+  //read configuration from FS json
+  Serial.println("mounting FS...");
+  if (SPIFFS.begin()) {
+    if (SPIFFS.exists("/config.json")) {
+      //file exists, reading and loading
+      Serial.println("reading config file");
+      File configFile = SPIFFS.open("/config.json", "r");
+      if (configFile) {
+        Serial.println("opened config file...");
+        size_t size = configFile.size();
+        // Allocate a buffer to store contents of the file.
+        std::unique_ptr<char[]> buf(new char[size]);
+
+        configFile.readBytes(buf.get(), size);
+        DynamicJsonBuffer jsonBuffer;
+        JsonObject& json = jsonBuffer.parseObject(buf.get());
+        json.printTo(Serial); // debug output to console
+        if (json.success()) {
+          Serial.println("\nparsed json");
+          if ( json["Networks"].is<JsonArray>() ) {
+            for (int i=0; i < json["Networks"].size(); i++) {
+              auto obj = json["Networks"][i];
+
+              // add existing networks and credentials
+              wifiManager.addAP(obj["SSID"], obj["Password"]);
+            }
+          }
+        } else {
+          Serial.println("failed to load json config");
+          return;
+        }
+      }
+    }
+    SPIFFS.end();
+  } else {
+    Serial.println("failed to mount FS -> format");
+    SPIFFS.format();
+  }
+}
+
+void save(WiFiManager &wifiManager) {
+  //save the custom parameters to FS
+  if (SPIFFS.begin()) {
+    Serial.println("saving config...");
+    DynamicJsonBuffer jsonBuffer;
+    JsonObject& json = jsonBuffer.createObject();
+    JsonArray& networks = json.createNestedArray("Networks");
+
+    // encode known networks to JSON
+    for (int i = 0; auto ap = wifiManager.getAP(i); i++ ) {
+      JsonObject& obj = jsonBuffer.createObject();
+      obj["SSID"] = ap->ssid;
+      obj["Password"] = ap->pass;
+      networks.add(obj);
+    }
+
+    File configFile = SPIFFS.open("/config.json", "w");
+    if (!configFile) {
+      Serial.println("failed to open config file for writing");
+      return;
+    }
+
+    json.printTo(Serial); Serial.println(); // debug output to console
+    json.printTo(configFile);
+    configFile.close();
+    SPIFFS.end();
+  }
+}
+
+//flag for saving data
+bool shouldSaveConfig = false;
+//callback notifying us of the need to save config
+void saveConfigCallback () {
+  shouldSaveConfig = true;
+}
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  
+  //WiFiManager
+  //Local intialization. Once its business is done, there is no need to keep it around
+  WiFiManager wifiManager;
+  //reset settings - for testing
+  wifiManager.resetSettings();
+
+  // load known access points
+  load(wifiManager);
+
+  //set config save notify callback
+  wifiManager.setSaveConfigCallback(saveConfigCallback);
+  
+  //fetches ssid and pass and tries to connect
+  //if it does not connect it starts an access point with the specified name
+  //here  "AutoConnectAP"
+  //and goes into a blocking loop awaiting configuration
+  if(!wifiManager.autoConnect()) {
+    Serial.println("failed to connect and hit timeout");
+    //reset and try again, or maybe put it to deep sleep
+    ESP.reset();
+    delay(1000);
+  } 
+
+  // save known access points
+  if ( shouldSaveConfig )
+    save(wifiManager);
+
+  //if you get here you have connected to the WiFi
+  Serial.println();
+  Serial.print("connected to: "); Serial.println(WiFi.SSID());
+  Serial.print("local ip: "); Serial.println(WiFi.localIP());
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+}


### PR DESCRIPTION
I added some code to handle multiple networks and credentials.
If the connection to the last connected network failed, a list of known networks will be searched for the strongest AP in reach. The known networks can be load and stored to the internal FS (see examlpes/AutoConnectMultipleNetworksWithFS).
Unlike the ESP8266WiFiMulti it will not re-scan or reconnect to another network when the connection is lost. So, no need to run anything in the main loop.
(old PR: #411)