### PR TITLE
disable wps by default, enable if its enabled in core

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -654,6 +654,7 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass) {
 
   DEBUG_WM(DEBUG_VERBOSE,F("Connection result:"),getWLStatusString(connRes));
 
+#ifdef NO_EXTRA_4K_HEAP
   // do WPS, if WPS options enabled and not connected and no password was supplied
   // @todo this seems like wrong place for this, is it a fallback or option?
   if (_tryWPS && connRes != WL_CONNECTED && pass == "") {
@@ -661,6 +662,7 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass) {
     // should be connected at the end of WPS
     connRes = waitForConnectResult();
   }
+#endif
 
   if(connRes != WL_SCAN_COMPLETED){
     updateConxResult(connRes);
@@ -782,6 +784,7 @@ uint8_t WiFiManager::waitForConnectResult(uint16_t timeout) {
   return status;
 }
 
+#ifdef NO_EXTRA_4K_HEAP
 void WiFiManager::startWPS() {
   DEBUG_WM(F("START WPS"));
   #ifdef ESP8266  
@@ -791,7 +794,7 @@ void WiFiManager::startWPS() {
   #endif
   DEBUG_WM(F("END WPS"));
 }
-
+#endif
 
 String WiFiManager::getHTTPHead(String title){
   String page;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -290,7 +290,9 @@ class WiFiManager
     int            _staShowDns            = 0;     // ternary always show dns, only if not set in code, never(cannot change dns via web!)
     boolean       _removeDuplicateAPs     = true;  // remove dup aps from wifiscan
     boolean       _shouldBreakAfterConfig = false; // stop configportal on save failure
+#ifdef NO_EXTRA_4K_HEAP
     boolean       _tryWPS                 = false; // try WPS on save failure, unsupported
+#endif
     boolean       _configPortalIsBlocking = true;  // configportal enters blocking loop 
     boolean       _enableCaptivePortal    = true;  // enable captive portal redirection
     boolean       _userpersistent         = true;  // users preffered persistence to restore
@@ -316,7 +318,9 @@ class WiFiManager
     void          _end();
 
     void          setupConfigPortal();
+#ifdef NO_EXTRA_4K_HEAP
     void          startWPS();
+#endif
     bool          startAP();
 
     uint8_t       connectWifi(String ssid, String pass);


### PR DESCRIPTION
In https://github.com/esp8266/Arduino/pull/4889 the core was modified to disable WPS by default.  Its only enabled if NO_EXTRA_4K_HEAP is defined.  To enable you must re-run the board generator with --noextra4kheap. This adds #ifdef NO_EXTRA_4K_HEAP around WPS usage so it won't generate compiler errors.
