### PR TITLE
fix bad progmem access

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1186,7 +1186,7 @@ void WiFiManager::handleWifiSave() {
   page += FPSTR(HTTP_END);
 
   server->sendHeader(FPSTR(HTTP_HEAD_CL), String(page.length()));
-  server->sendHeader(FPSTR(HTTP_HEAD_CORS), HTTP_HEAD_CORS_ALLOW_ALL);
+  server->sendHeader(FPSTR(HTTP_HEAD_CORS), FPSTR(HTTP_HEAD_CORS_ALLOW_ALL));
   server->send(200, FPSTR(HTTP_HEAD_CT), page);
 
   DEBUG_WM(DEBUG_DEV,F("Sent wifi save page"));

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1186,7 +1186,7 @@ void WiFiManager::handleWifiSave() {
   page += FPSTR(HTTP_END);
 
   server->sendHeader(FPSTR(HTTP_HEAD_CL), String(page.length()));
-  server->sendHeader(HTTP_HEAD_CORS, HTTP_HEAD_CORS_ALLOW_ALL);
+  server->sendHeader(FPSTR(HTTP_HEAD_CORS), HTTP_HEAD_CORS_ALLOW_ALL);
   server->send(200, FPSTR(HTTP_HEAD_CT), page);
 
   DEBUG_WM(DEBUG_DEV,F("Sent wifi save page"));


### PR DESCRIPTION
https://github.com/tzapu/WiFiManager/pull/608 introduced a new header located in PROGMEM but did not use FPSTR() in its use causing crashes.

Exception Cause: 3  [LoadStoreError: Processor internal physical address or data error during load or store]
