### PR TITLE
Fix custom html from out of scope

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1115,7 +1115,7 @@ String WiFiManager::getParamOut(){
     char parLength[5];
     // add the extra parameters to the form
     for (int i = 0; i < _paramsCount; i++) {
-      if (_params[i] == NULL || (_params[i]->_length == 0 && _params[i]->_customHTML == NULL)) {
+      if (_params[i] == NULL || (_params[i]->_length == 0 && (_params[i]->_customHTML == NULL || _params[i]->_customHTML[0] == '\0'))) {
         DEBUG_WM(DEBUG_ERROR,"[ERROR] WiFiManagerParameter is out of scope");
         break;
       }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1115,7 +1115,7 @@ String WiFiManager::getParamOut(){
     char parLength[5];
     // add the extra parameters to the form
     for (int i = 0; i < _paramsCount; i++) {
-      if (_params[i] == NULL || _params[i]->_length == 0) {
+      if (_params[i] == NULL || (_params[i]->_length == 0 && _params[i]->_customHTML == NULL)) {
         DEBUG_WM(DEBUG_ERROR,"[ERROR] WiFiManagerParameter is out of scope");
         break;
       }


### PR DESCRIPTION
Over eager "parameter out of scope" check:
Custom html was triggering "parameter out of scope" as its length was 0 causing parameters not to be added.  In my case I have a "label" (custom html) first and none of my 31 parameters were showing up.