### PR TITLE
Hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Current development going on here :arrow_right: [Development Branch](https://github.com/tzapu/WiFiManager/tree/development)
+
 # WiFiManager
 ESP8266 WiFi Connection manager with fallback web configuration portal
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -197,9 +197,20 @@ boolean WiFiManager::startConfigPortal() {
 }
 
 boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPassword) {
-  //setup AP
-  WiFi.mode(WIFI_AP_STA);
-  DEBUG_WM(F("SET AP STA"));
+  
+  if(!WiFi.isConnected()){
+    WiFi.persistent(false);
+    // disconnect sta, start ap
+    WiFi.disconnect(); //  this alone is not enough to stop the autoconnecter
+    WiFi.mode(WIFI_AP);
+    WiFi.persistent(true);
+  } 
+  else {
+    //setup AP
+    WiFi.mode(WIFI_AP_STA);
+    DEBUG_WM(F("SET AP STA"));
+  }
+
 
   _apName = apName;
   _apPassword = apPassword;

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -308,11 +308,13 @@ int WiFiManager::connectWifi(String ssid, String pass) {
   DEBUG_WM ("Connection result: ");
   DEBUG_WM ( connRes );
   //not connected, WPS enabled, no pass - first attempt
+  #ifdef NO_EXTRA_4K_HEAP
   if (_tryWPS && connRes != WL_CONNECTED && pass == "") {
     startWPS();
     //should be connected at the end of WPS
     connRes = waitForConnectResult();
   }
+  #endif
   return connRes;
 }
 


### PR DESCRIPTION
Add
```
WiFiManagerParameter::WiFiManagerParameter(const char *id, int length, const char *custom) {
  _id = id;
  _placeholder = NULL;
  _length = length;
  _value = NULL;

  _customHTML = custom;
}
```
This way [#L522](https://github.com/tzapu/WiFiManager/blob/32495668d8ac691d72ec77b5e423c6f8d3d845b7/WiFiManager.cpp#L522) to:
```
if (_params[i]->getValue() != NULL) {
```
Would allow to use custom HTML as <select> and drop-down list for example.

Because originally 
```
_id = NULL;
``` 
this line [[#L598]](https://github.com/tzapu/WiFiManager/blob/32495668d8ac691d72ec77b5e423c6f8d3d845b7/WiFiManager.cpp#L598) won't retrieve value from the drop-down list.

[screenshot_20180803-230205_chrome](https://user-images.githubusercontent.com/34199302/43639883-db1e6d0a-9771-11e8-8c96-13a5bbcca5e9.jpg)
