### PR TITLE
Set value

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -71,7 +71,7 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
   int deflength = strlen(defaultValue); // length actual
   // use the defult length if it's longer, 
   // @todo consider it might be useful to fail, so user knows they were wrong
-  if(_length < length){
+  if(_length < deflength){
     // Serial.println("defaultValue length mismatch");
     _length = deflength;
   }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -68,20 +68,11 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
     return;
   }
   _length       = length;
-  int deflength = strlen(defaultValue); // length actual
-  // use the defult length if it's longer, 
-  // @todo consider it might be useful to fail, so user knows they were wrong
-  if(_length < deflength){
-    // Serial.println("defaultValue length mismatch");
-    _length = deflength;
-  }
-  _value = new char[_length + 1];
-  for (int i = 0; i < _length + 1; i++) {
-    _value[i] = 0;
-  }
+  _value = new char[_length + 1]; 
+  memset(_value, 0, _length + 1); // explicit null
+  
   if (defaultValue != NULL) {
     strncpy(_value, defaultValue, _length);
-    _value[_length] = '\0'; // explicit null
   }
 }
 const char* WiFiManagerParameter::getValue() {


### PR DESCRIPTION
Firstly, I correct your error: 
`if(_length < length){` to `if(_length < deflength){`
but it is dangerous to use strlen for default value cause overflow.
I remove you code to increate length. 

Secondly,
a. memset
b. need not _value[_length] = '\0'; case already memset with length+1

1. Now init() and getValue() are symmetrical for parameter length: you set and get with same limit.
2. init() parameter is safe: you can use EEPROM buffer without null terminator.

