### PR TITLE
wifimanager.cpp / wifimanager.h

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -12,6 +12,8 @@
 
 #include "WiFiManager.h"
 
+#if defined(ESP8266) || defined(ESP32)
+
 #ifdef ESP32
 uint8_t WiFiManager::_lastconxresulttmp = WL_IDLE_STATUS;
 #endif
@@ -2700,3 +2702,5 @@ void WiFiManager::WiFi_autoReconnect(){
     // }
   #endif
 }
+
+#endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -10,8 +10,11 @@
  * @license MIT
  */
 
+
 #ifndef WiFiManager_h
 #define WiFiManager_h
+
+#if defined(ESP8266) || defined(ESP32)
 
 #ifdef ESP8266
 #include <core_version.h>
@@ -504,5 +507,7 @@ class WiFiManager
       return false;
     }
 };
+
+#endif
 
 #endif


### PR DESCRIPTION
I figured out, that there is no check on the hardware plattform, which is currently selected.
There are serval plattforms, which does not compile, i suggest adding a if defined check to the preprocessor.

Why is this useful?

I've a multi plattform Project. I used two seprerate source code projects in the past, but now i want to merge them. When i try to compile my project with an AVR Board, it fails, because it trys to compile the wifi lib but doesn't find serval used libs.


-added define that checks on esp32 or esp8266. If another hardware is selectec, then do not try to compile this code.