### PR TITLE
Fix ArduinoJson (Using ARDUINOJSON_VERSION_MAJOR)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,13 +19,24 @@ https://github.com/esp8266/Arduino/blob/master/doc/Troubleshooting/debugging.rst
 ### Basic Infos
 
 #### Hardware
-WiFimanager Branch/Release:  Development
+WiFimanager Branch/Release:
+- [ ] Master
+- [ ] Development
 
-Esp8266/Esp32: 
+Esp8266/Esp32:
+- [ ] ESP8266
+- [ ] ESP32
 
 Hardware:			ESP-12e, esp01, esp25
+- [ ] ESP01
+- [ ] ESP12 E/F/S (nodemcu, wemos, feather)
+- [ ] Other
 
-Core Version:      	2.4.0, staging
+
+ESP Core Version:	2.4.0, staging
+- [ ] 2.3.0
+- [ ] 2.4.0
+- [ ] staging (master/dev)
 
 ### Description
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,6 @@
 ## PLEASE TRY DEVELOPMENT BRANCH before submitting bugs on release or master, in case they were already fixed. ##
 
 ## POST SERIAL OUTPUT !
-## POST SERIAL OUTPUT !
-## POST SERIAL OUTPUT !
 
 Issues without basic info will be ignored or closed!
 
@@ -19,21 +17,21 @@ https://github.com/esp8266/Arduino/blob/master/doc/Troubleshooting/debugging.rst
 ### Basic Infos
 
 #### Hardware
-WiFimanager Branch/Release:
+**WiFimanager Branch/Release:**
 - [ ] Master
 - [ ] Development
 
-Esp8266/Esp32:
+**Esp8266/Esp32:**
 - [ ] ESP8266
 - [ ] ESP32
 
-Hardware:			ESP-12e, esp01, esp25
+**Hardware:			ESP-12e, esp01, esp25**
 - [ ] ESP01
 - [ ] ESP12 E/F/S (nodemcu, wemos, feather)
 - [ ] Other
 
 
-ESP Core Version:	2.4.0, staging
+**ESP Core Version:	2.4.0, staging**
 - [ ] 2.3.0
 - [ ] 2.4.0
 - [ ] staging (master/dev)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,9 @@
 ## PLEASE TRY DEVELOPMENT BRANCH before submitting bugs on release or master, in case they were already fixed. ##
 
+## POST SERIAL OUTPUT !
+## POST SERIAL OUTPUT !
+## POST SERIAL OUTPUT !
+
 Issues without basic info will be ignored or closed!
 
 Please fill the info fields, it helps to get you faster support ;)

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -290,7 +290,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
   if (ssid != "") {
     WiFi.begin(ssid.c_str(), pass.c_str());
   } else {
-    if (WiFi.SSID()) {
+    if (WiFi.SSID() != "") {
       DEBUG_WM(F("Using last saved values, should be faster"));
       //trying to fix connection in progress hanging
       ETS_UART_INTR_DISABLE();

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -143,18 +143,17 @@ void WiFiManager::setupConfigPortal() {
   dnsServer->start(DNS_PORT, "*", WiFi.softAPIP());
 
   /* Setup web pages: root, wifi config pages, SO captive portal detectors and not found. */
-  server->on(String(F("/")), std::bind(&WiFiManager::handleRoot, this));
-  server->on(String(F("/wifi")), std::bind(&WiFiManager::handleWifi, this, true));
-  server->on(String(F("/0wifi")), std::bind(&WiFiManager::handleWifi, this, false));
-  server->on(String(F("/wifisave")), std::bind(&WiFiManager::handleWifiSave, this));
-  server->on(String(F("/i")), std::bind(&WiFiManager::handleInfo, this));
-  server->on(String(F("/r")), std::bind(&WiFiManager::handleReset, this));
+  server->on(String(F("/")).c_str(), std::bind(&WiFiManager::handleRoot, this));
+  server->on(String(F("/wifi")).c_str(), std::bind(&WiFiManager::handleWifi, this, true));
+  server->on(String(F("/0wifi")).c_str(), std::bind(&WiFiManager::handleWifi, this, false));
+  server->on(String(F("/wifisave")).c_str(), std::bind(&WiFiManager::handleWifiSave, this));
+  server->on(String(F("/i")).c_str(), std::bind(&WiFiManager::handleInfo, this));
+  server->on(String(F("/r")).c_str(), std::bind(&WiFiManager::handleReset, this));
   //server->on("/generate_204", std::bind(&WiFiManager::handle204, this));  //Android/Chrome OS captive portal check.
-  server->on(String(F("/fwlink")), std::bind(&WiFiManager::handleRoot, this));  //Microsoft captive portal. Maybe not needed. Might be handled by notFound handler.
+  server->on(String(F("/fwlink")).c_str(), std::bind(&WiFiManager::handleRoot, this));  //Microsoft captive portal. Maybe not needed. Might be handled by notFound handler.
   server->onNotFound (std::bind(&WiFiManager::handleNotFound, this));
   server->begin(); // Web server start
   DEBUG_WM(F("HTTP server started"));
-
 }
 
 boolean WiFiManager::autoConnect() {

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -282,7 +282,7 @@ int WiFiManager::connectWifi(String ssid, String pass) {
     DEBUG_WM(WiFi.localIP());
   }
   //fix for auto connect racing issue
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED && (WiFi.SSID() == ssid)) {
     DEBUG_WM(F("Already connected. Bailing out."));
     return WL_CONNECTED;
   }

--- a/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
+++ b/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
@@ -7,9 +7,6 @@
 
 #include <ArduinoJson.h>          //https://github.com/bblanchon/ArduinoJson
 
-//Comment out this line if you are still using ArduinoJsonV5
-#define UseJsonV6
-
 //define your default values here, if there are different values in config.json, they are overwritten.
 char mqtt_server[40];
 char mqtt_port[6] = "8080";
@@ -49,7 +46,7 @@ void setup() {
 
         configFile.readBytes(buf.get(), size);
 
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
         DynamicJsonDocument json(1024);
         auto deserializeError = deserializeJson(json, buf.get());
         serializeJson(json, Serial);
@@ -136,7 +133,7 @@ void setup() {
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
     DynamicJsonDocument json(1024);
 #else
     DynamicJsonBuffer jsonBuffer;
@@ -151,7 +148,7 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
     serializeJson(json, Serial);
     serializeJson(json, configFile);
 #else

--- a/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
+++ b/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
@@ -1,13 +1,14 @@
 #include <FS.h>                   //this needs to be first, or it all crashes and burns...
-
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
-
 //needed for library
 #include <DNSServer.h>
 #include <ESP8266WebServer.h>
 #include <WiFiManager.h>          //https://github.com/tzapu/WiFiManager
 
 #include <ArduinoJson.h>          //https://github.com/bblanchon/ArduinoJson
+
+//Comment out this line if you are still using ArduinoJsonV5
+#define UseJsonV6
 
 //define your default values here, if there are different values in config.json, they are overwritten.
 char mqtt_server[40];
@@ -22,7 +23,6 @@ void saveConfigCallback () {
   Serial.println("Should save config");
   shouldSaveConfig = true;
 }
-
 
 void setup() {
   // put your setup code here, to run once:
@@ -48,16 +48,22 @@ void setup() {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
+
+#ifdef UseJsonV6
+        DynamicJsonDocument json(1024);
+        auto deserializeError = deserializeJson(json, buf.get());
+        serializeJson(json, Serial);
+        if ( ! deserializeError ) {
+#else
         DynamicJsonBuffer jsonBuffer;
         JsonObject& json = jsonBuffer.parseObject(buf.get());
         json.printTo(Serial);
         if (json.success()) {
+#endif
           Serial.println("\nparsed json");
-
           strcpy(mqtt_server, json["mqtt_server"]);
           strcpy(mqtt_port, json["mqtt_port"]);
           strcpy(blynk_token, json["blynk_token"]);
-
         } else {
           Serial.println("failed to load json config");
         }
@@ -68,8 +74,6 @@ void setup() {
     Serial.println("failed to mount FS");
   }
   //end read
-
-
 
   // The extra parameters to be configured (can be either global or just in the setup)
   // After connecting, parameter.getValue() will get you the configured value
@@ -86,8 +90,8 @@ void setup() {
   wifiManager.setSaveConfigCallback(saveConfigCallback);
 
   //set static ip
-  wifiManager.setSTAStaticIPConfig(IPAddress(10,0,1,99), IPAddress(10,0,1,1), IPAddress(255,255,255,0));
-  
+  wifiManager.setSTAStaticIPConfig(IPAddress(10, 0, 1, 99), IPAddress(10, 0, 1, 1), IPAddress(255, 255, 255, 0));
+
   //add all your parameters here
   wifiManager.addParameter(&custom_mqtt_server);
   wifiManager.addParameter(&custom_mqtt_port);
@@ -99,7 +103,7 @@ void setup() {
   //set minimu quality of signal so it ignores AP's under that quality
   //defaults to 8%
   //wifiManager.setMinimumSignalQuality();
-  
+
   //sets timeout until configuration portal gets turned off
   //useful to make it all retry or go to sleep
   //in seconds
@@ -124,12 +128,20 @@ void setup() {
   strcpy(mqtt_server, custom_mqtt_server.getValue());
   strcpy(mqtt_port, custom_mqtt_port.getValue());
   strcpy(blynk_token, custom_blynk_token.getValue());
+  Serial.println("The values in the file are: ");
+  Serial.println("\tmqtt_server : " + String(mqtt_server));
+  Serial.println("\tmqtt_port : " + String(mqtt_port));
+  Serial.println("\tblynk_token : " + String(blynk_token));
 
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
+#ifdef UseJsonV6
+    DynamicJsonDocument json(1024);
+#else
     DynamicJsonBuffer jsonBuffer;
     JsonObject& json = jsonBuffer.createObject();
+#endif
     json["mqtt_server"] = mqtt_server;
     json["mqtt_port"] = mqtt_port;
     json["blynk_token"] = blynk_token;
@@ -139,19 +151,22 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
+#ifdef UseJsonV6
+    serializeJson(json, Serial);
+    serializeJson(json, configFile);
+#else
     json.printTo(Serial);
     json.printTo(configFile);
+#endif
     configFile.close();
     //end save
   }
 
   Serial.println("local ip");
   Serial.println(WiFi.localIP());
-
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
-
 
 }

--- a/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
+++ b/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
@@ -9,9 +9,6 @@
 
 #include <ArduinoJson.h>          //https://github.com/bblanchon/ArduinoJson
 
-//Comment out this line if you are still using ArduinoJsonV5
-#define UseJsonV6
-
 //define your default values here, if there are different values in config.json, they are overwritten.
 //length should be max size + 1
 char mqtt_server[40];
@@ -55,7 +52,7 @@ void setup() {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
         DynamicJsonDocument json(1024);
         auto deserializeError = deserializeJson(json, buf.get());
         serializeJson(json, Serial);
@@ -157,7 +154,7 @@ void setup() {
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
     DynamicJsonDocument json(1024);
 #else
     DynamicJsonBuffer jsonBuffer;
@@ -176,7 +173,7 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
-#ifdef UseJsonV6
+#ifdef ARDUINOJSON_VERSION_MAJOR >= 6
     serializeJson(json, Serial);
     serializeJson(json, configFile);
 #else

--- a/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
+++ b/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
@@ -9,11 +9,14 @@
 
 #include <ArduinoJson.h>          //https://github.com/bblanchon/ArduinoJson
 
+//Comment out this line if you are still using ArduinoJsonV5
+#define UseJsonV6
+
 //define your default values here, if there are different values in config.json, they are overwritten.
-//length should be max size + 1 
+//length should be max size + 1
 char mqtt_server[40];
 char mqtt_port[6] = "8080";
-char blynk_token[33] = "YOUR_BLYNK_TOKEN";
+char blynk_token[34] = "YOUR_BLYNK_TOKEN";
 //default custom static IP
 char static_ip[16] = "10.0.1.56";
 char static_gw[16] = "10.0.1.1";
@@ -52,29 +55,29 @@ void setup() {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
+#ifdef UseJsonV6
+        DynamicJsonDocument json(1024);
+        auto deserializeError = deserializeJson(json, buf.get());
+        serializeJson(json, Serial);
+        if ( ! deserializeError ) {
+#else
         DynamicJsonBuffer jsonBuffer;
         JsonObject& json = jsonBuffer.parseObject(buf.get());
         json.printTo(Serial);
         if (json.success()) {
+#endif
           Serial.println("\nparsed json");
 
           strcpy(mqtt_server, json["mqtt_server"]);
           strcpy(mqtt_port, json["mqtt_port"]);
           strcpy(blynk_token, json["blynk_token"]);
 
-          if(json["ip"]) {
+          if (json["ip"]) {
             Serial.println("setting custom ip from config");
-            //static_ip = json["ip"];
             strcpy(static_ip, json["ip"]);
             strcpy(static_gw, json["gateway"]);
             strcpy(static_sn, json["subnet"]);
-            //strcat(static_ip, json["ip"]);
-            //static_gw = json["gateway"];
-            //static_sn = json["subnet"];
             Serial.println(static_ip);
-/*            Serial.println("converting ip");
-            IPAddress ip = ipFromCharArray(static_ip);
-            Serial.println(ip);*/
           } else {
             Serial.println("no custom ip in config");
           }
@@ -107,13 +110,13 @@ void setup() {
   wifiManager.setSaveConfigCallback(saveConfigCallback);
 
   //set static ip
-  IPAddress _ip,_gw,_sn;
+  IPAddress _ip, _gw, _sn;
   _ip.fromString(static_ip);
   _gw.fromString(static_gw);
   _sn.fromString(static_sn);
 
   wifiManager.setSTAStaticIPConfig(_ip, _gw, _sn);
-  
+
   //add all your parameters here
   wifiManager.addParameter(&custom_mqtt_server);
   wifiManager.addParameter(&custom_mqtt_port);
@@ -125,7 +128,7 @@ void setup() {
   //set minimu quality of signal so it ignores AP's under that quality
   //defaults to 8%
   wifiManager.setMinimumSignalQuality();
-  
+
   //sets timeout until configuration portal gets turned off
   //useful to make it all retry or go to sleep
   //in seconds
@@ -154,8 +157,12 @@ void setup() {
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
+#ifdef UseJsonV6
+    DynamicJsonDocument json(1024);
+#else
     DynamicJsonBuffer jsonBuffer;
     JsonObject& json = jsonBuffer.createObject();
+#endif
     json["mqtt_server"] = mqtt_server;
     json["mqtt_port"] = mqtt_port;
     json["blynk_token"] = blynk_token;
@@ -169,8 +176,13 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
-    json.prettyPrintTo(Serial);
+#ifdef UseJsonV6
+    serializeJson(json, Serial);
+    serializeJson(json, configFile);
+#else
+    json.printTo(Serial);
     json.printTo(configFile);
+#endif
     configFile.close();
     //end save
   }
@@ -183,6 +195,4 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-
-
 }

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": "espressif8266",
-  "version": "0.12"
+  "version": "0.13"
 }

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": "espressif8266",
-  "version": "0.15-beta"
+  "version": "0.15.0-beta"
 }

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": "espressif8266",
-  "version": "0.14"
+  "version": "0.15-beta"
 }

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": "espressif8266",
-  "version": "0.13"
+  "version": "0.14"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiManager
-version=0.13
+version=0.14
 author=tzapu
 maintainer=tzapu
 sentence=ESP8266 WiFi Connection manager with fallback web configuration portal

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiManager
-version=0.14
+version=0.15-beta
 author=tzapu
 maintainer=tzapu
 sentence=ESP8266 WiFi Connection manager with fallback web configuration portal

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiManager
-version=0.12
+version=0.13
 author=tzapu
 maintainer=tzapu
 sentence=ESP8266 WiFi Connection manager with fallback web configuration portal

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiManager
-version=0.15-beta
+version=0.15.0-beta
 author=tzapu
 maintainer=tzapu
 sentence=ESP8266 WiFi Connection manager with fallback web configuration portal


### PR DESCRIPTION
This is relates to the ArduinoJson 5 / 6 changes.
I took what @bigjohnson did in a502456 and just added a #define UseJsonV6 option that can be commented out if you want to use ArduinoJsonV5.
Tested on ArduinoJson V 5.13 and ArduinoJson V 6.13 (Latest as at 14/01/2020)

This also links to #654 and #812 
- [x] update examples to be compatible with future arduinojson library
- [x] Maybe add support in the example in question for both versioons somehow?
- [x] Can also Close #945 