### PR TITLE
trivial: WiFiManagerParameter get accessors should work on const

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -88,25 +88,25 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
     strncpy(_value, defaultValue, _length);
   }
 }
-const char* WiFiManagerParameter::getValue() {
+const char* WiFiManagerParameter::getValue() const {
   return _value;
 }
-const char* WiFiManagerParameter::getID() {
+const char* WiFiManagerParameter::getID() const {
   return _id;
 }
-const char* WiFiManagerParameter::getPlaceholder() {
+const char* WiFiManagerParameter::getPlaceholder() const {
   return _label;
 }
-const char* WiFiManagerParameter::getLabel() {
+const char* WiFiManagerParameter::getLabel() const {
   return _label;
 }
-int WiFiManagerParameter::getValueLength() {
+int WiFiManagerParameter::getValueLength() const {
   return _length;
 }
-int WiFiManagerParameter::getLabelPlacement() {
+int WiFiManagerParameter::getLabelPlacement() const {
   return _labelPlacement;
 }
-const char* WiFiManagerParameter::getCustomHTML() {
+const char* WiFiManagerParameter::getCustomHTML() const {
   return _customHTML;
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -115,13 +115,13 @@ class WiFiManagerParameter {
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
     ~WiFiManagerParameter();
 
-    const char *getID();
-    const char *getValue();
-    const char *getLabel();
-    const char *getPlaceholder(); // @deprecated, use getLabel
-    int         getValueLength();
-    int         getLabelPlacement();
-    const char *getCustomHTML();
+    const char *getID() const;
+    const char *getValue() const;
+    const char *getLabel() const;
+    const char *getPlaceholder() const; // @deprecated, use getLabel
+    int         getValueLength() const;
+    int         getLabelPlacement() const;
+    const char *getCustomHTML() const;
     void        setValue(const char *defaultValue, int length);
 
   protected:


### PR DESCRIPTION

Enhancement: It should be okay to invoke getID() and getValue() in a
const instance of the WiFiManagerParameter class.

For usage example, see: https://github.com/flavio-fernandes/persistWifiSetting/commit/135adb1c7e436db1ed92ccd5eb522b9ae418b216
