### PR TITLE
Update WiFiManager.cpp

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1366,7 +1366,7 @@ void WiFiManager::handleWifiSave() {
     page += FPSTR(HTTP_PARAMSAVED);
   }
   else {
-    String page = getHTTPHead(FPSTR(S_titlewifisaved)); // @token titlewifisaved
+    page = getHTTPHead(FPSTR(S_titlewifisaved)); // @token titlewifisaved
     page += FPSTR(HTTP_SAVED);
   }
   page += FPSTR(HTTP_END);


### PR DESCRIPTION
Fixed bug where, after clicking "Save", it would display an empty page to the user, instead of the wifi save page. (due to local variable)