### PR TITLE
 Fix opening hotspot in autoconnect after reset

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -317,6 +317,20 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
     DEBUG_WM(F("STA IP Address:"),WiFi.localIP());
     _lastconxresult = WL_CONNECTED;
 
+    DEBUG_WM(DEBUG_VERBOSE,F("disconnect configportal"));
+    bool ret = false;
+    ret = WiFi.softAPdisconnect(false);
+    if(!ret)DEBUG_WM(DEBUG_ERROR,F("[ERROR] disconnect autoconnect - softAPdisconnect FAILED"));
+    delay(1000);
+    DEBUG_WM(DEBUG_VERBOSE,"restoring usermode",getModeString(_usermode));
+    WiFi_Mode(_usermode); // restore users wifi mode, BUG https://github.com/esp8266/Arduino/issues/4372
+    if(WiFi.status()==WL_IDLE_STATUS){
+      WiFi.reconnect(); // restart wifi since we disconnected it in startconfigportal
+      DEBUG_WM(DEBUG_VERBOSE,"WiFi Reconnect, was idle");
+    }
+    DEBUG_WM(DEBUG_VERBOSE,"wifi status:",getWLStatusString(WiFi.status()));
+    DEBUG_WM(DEBUG_VERBOSE,"wifi mode:",getModeString(WiFi.getMode()));
+
     if((String)_hostname != ""){
       #ifdef ESP8266
         DEBUG_WM(DEBUG_DEV,"hostname: STA",WiFi.hostname());


### PR DESCRIPTION
I noticed that a hotspot is opened if the ESP8266 reconnects to a previous wifi using autoconnect after a reset. 

I use the same workaround like in the [shutdownConfigPortal](https://github.com/tzapu/WiFiManager/blob/4a98ba0e29606c684e66fa80e53f1293a269540b/WiFiManager.cpp#L700) method.