### PR TITLE
Update FS examples to use Arduinojson 6 (Fixes #1059)

### DIFF
--- a/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
+++ b/examples/AutoConnectWithFSParameters/AutoConnectWithFSParameters.ino
@@ -48,10 +48,10 @@ void setup() {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
-        DynamicJsonBuffer jsonBuffer;
-        JsonObject& json = jsonBuffer.parseObject(buf.get());
-        json.printTo(Serial);
-        if (json.success()) {
+        StaticJsonDocument<256> json;
+        DeserializationError jsonError = deserializeJson(json, buf.get());
+        serializeJsonPretty(json, Serial);
+        if (!jsonError) {
           Serial.println("\nparsed json");
 
           strcpy(mqtt_server, json["mqtt_server"]);
@@ -128,8 +128,8 @@ void setup() {
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
-    DynamicJsonBuffer jsonBuffer;
-    JsonObject& json = jsonBuffer.createObject();
+    StaticJsonDocument<256> json;
+
     json["mqtt_server"] = mqtt_server;
     json["mqtt_port"] = mqtt_port;
     json["blynk_token"] = blynk_token;
@@ -139,8 +139,8 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
-    json.printTo(Serial);
-    json.printTo(configFile);
+    serializeJsonPretty(json, Serial);
+    serializeJson(json, configFile);
     configFile.close();
     //end save
   }

--- a/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
+++ b/examples/AutoConnectWithFSParametersAndCustomIP/AutoConnectWithFSParametersAndCustomIP.ino
@@ -52,10 +52,10 @@ void setup() {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
-        DynamicJsonBuffer jsonBuffer;
-        JsonObject& json = jsonBuffer.parseObject(buf.get());
-        json.printTo(Serial);
-        if (json.success()) {
+        StaticJsonDocument<256> json;
+        DeserializationError jsonError = deserializeJson(json, buf.get());
+        serializeJsonPretty(json, Serial);
+        if (!jsonError) {
           Serial.println("\nparsed json");
 
           strcpy(mqtt_server, json["mqtt_server"]);
@@ -154,8 +154,8 @@ void setup() {
   //save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("saving config");
-    DynamicJsonBuffer jsonBuffer;
-    JsonObject& json = jsonBuffer.createObject();
+    StaticJsonDocument<256> json;
+    
     json["mqtt_server"] = mqtt_server;
     json["mqtt_port"] = mqtt_port;
     json["blynk_token"] = blynk_token;
@@ -169,8 +169,8 @@ void setup() {
       Serial.println("failed to open config file for writing");
     }
 
-    json.prettyPrintTo(Serial);
-    json.printTo(configFile);
+    serializeJsonPretty(json, Serial);
+    serializeJson(json, configFile);
     configFile.close();
     //end save
   }


### PR DESCRIPTION
Small direct updates to change the AutoConnectWithFSParameters and AutoConnectWithFSParametersAndCustomIP examples to make them compatible with Arduinojson 6