### PR TITLE
Add support for static ip address configuration in the config web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ or if you want to use and auto generated name from 'ESP' and the esp's Chip ID u
 ```cpp
 wifiManager.autoConnect();
 ```
+it is also possible to configure static IP/Gateway/Subnet addresses through the web page:
+```cpp
+wifiManager.autoConnect(true);
+```
+Or when specifying the AP name and password:
+```cpp
+wifiManager.autoConnect("AP-NAME", "AP-PASSWORD", true);
+```
 
 After you write your sketch and start the ESP, it will try to connect to WiFi. If it fails it starts in Access Point mode.
 While in AP mode, connect to it then open a browser to the gateway IP, default 192.168.4.1, configure wifi, save and it should reboot and connect.

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -156,14 +156,16 @@ void WiFiManager::setupConfigPortal() {
   DEBUG_WM(F("HTTP server started"));
 }
 
-boolean WiFiManager::autoConnect() {
+boolean WiFiManager::autoConnect(boolean showStaticIPFields) {
   String ssid = "ESP" + String(ESP.getChipId());
-  return autoConnect(ssid.c_str(), NULL);
+  return autoConnect(ssid.c_str(), NULL, showStaticIPFields);
 }
 
-boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
+boolean WiFiManager::autoConnect(char const *apName, char const *apPassword, boolean showStaticIPFields) {
   DEBUG_WM(F(""));
   DEBUG_WM(F("AutoConnect"));
+
+  _sta_show_static_fields = showStaticIPFields;
 
   // read eeprom for ssid and pass
   //String ssid = getSSID();
@@ -580,14 +582,14 @@ void WiFiManager::handleWifi(boolean scan) {
     page += "<br/>";
   }
 
-  if (_sta_static_ip) {
+  if (_sta_show_static_fields || _sta_static_ip) {
 
     String item = FPSTR(HTTP_FORM_PARAM);
     item.replace("{i}", "ip");
     item.replace("{n}", "ip");
     item.replace("{p}", "Static IP");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_ip.toString());
+    item.replace("{v}", (_sta_static_ip ? _sta_static_ip.toString() : ""));
 
     page += item;
 
@@ -596,7 +598,7 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "gw");
     item.replace("{p}", "Static Gateway");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_gw.toString());
+    item.replace("{v}", (_sta_static_gw ? _sta_static_gw.toString() : ""));
 
     page += item;
 
@@ -605,7 +607,7 @@ void WiFiManager::handleWifi(boolean scan) {
     item.replace("{n}", "sn");
     item.replace("{p}", "Subnet");
     item.replace("{l}", "15");
-    item.replace("{v}", _sta_static_sn.toString());
+    item.replace("{v}", (_sta_static_sn ? _sta_static_sn.toString() : ""));
 
     page += item;
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -74,8 +74,8 @@ class WiFiManager
     WiFiManager();
     ~WiFiManager();
 
-    boolean       autoConnect();
-    boolean       autoConnect(char const *apName, char const *apPassword = NULL);
+    boolean       autoConnect(boolean showStaticIPFields = false);
+    boolean       autoConnect(char const *apName, char const *apPassword = NULL, boolean showStaticIPFields = false);
 
     //if you want to always start the config portal, without trying to connect first
     boolean       startConfigPortal();
@@ -144,6 +144,7 @@ class WiFiManager
     IPAddress     _sta_static_ip;
     IPAddress     _sta_static_gw;
     IPAddress     _sta_static_sn;
+    boolean       _sta_show_static_fields = false;
 
     int           _paramsCount            = 0;
     int           _minimumQuality         = -1;


### PR DESCRIPTION
This PR will add support for adding static IP, gateway and subnet address fields to the setup page if the `true` parameter is passed to the `autoConnect()` method