### PR TITLE
Adding dependencies to library.json to facilitate working with platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,4 +26,21 @@
     "espressif32"
   ],
   "version": "2.0.3-alpha"
+  "dependencies":
+  [
+      {
+          "name": "DNSServer",
+          "version": "1.1.0"
+      },
+      {
+          "name": "WebServer",
+          "version": "1.0"
+      },
+      {
+          "name": "WiFi",
+          "version": "1.0"
+      }
+  ]
+
+
 }

--- a/library.json
+++ b/library.json
@@ -25,7 +25,7 @@
     "espressif8266",
     "espressif32"
   ],
-  "version": "2.0.3-alpha"
+  "version": "2.0.3-alpha",
   "dependencies":
   [
       {
@@ -38,6 +38,10 @@
       },
       {
           "name": "WiFi",
+          "version": "1.0"
+      },
+      {
+          "name": "FS",
           "version": "1.0"
       }
   ]


### PR DESCRIPTION
I added the dependencies section to facilitate the work with platformio. If missing, I had to add DNSServer, WebServer, WiFi and FS manually to the lib_deps section of the platformio.ini of my ESP32 projects using WiFiManager.

Best Christian 