### PR TITLE
Add Fast connect support

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -307,6 +307,9 @@ class WiFiManager
     // see _menutokens for ids
     void          setMenu(std::vector<const char*>& menu);
     void          setMenu(const char* menu[], uint8_t size);
+
+    // if true enable Fast connect mode
+    void          setFastConnectMode(bool enabled);
     
     // add params to its own menu page and remove from wifi, NOT TO BE COMBINED WITH setMenu!
     void          setParamsPage(bool enable);
@@ -453,6 +456,10 @@ class WiFiManager
     boolean       _disableIpFields        = false; // modify function of setShow_X_Fields(false), forces ip fields off instead of default show if set, eg. _staShowStaticFields=-1
 
     String        _wificountry            = "";  // country code, @todo define in strings lang
+	//fast mode to set mac address and channel during begin
+	boolean       _fastConnectMode        = false;
+	uint8_t*      _fastConnectBSSID;
+	uint32_t      _fastConnectChannel     = 0;
 
     // wrapper functions for handling setting and unsetting persistent for now.
     bool          esp32persistent         = false;
@@ -479,6 +486,7 @@ class WiFiManager
     uint8_t       waitForConnectResult();
     uint8_t       waitForConnectResult(uint16_t timeout);
     void          updateConxResult(uint8_t status);
+	uint8_t       getFastConfig(String ssid);
 
     // webserver handlers
     void          handleRoot();


### PR DESCRIPTION
The optional fast connect support uses the version of WiFi.begin with channel and router mac address defined. This avoids scanning operations during normal start up and reduces the start up connect time considerably (from 3 seconds down to 1 second).

This is particularly beneficial in deep sleep applications where the faster start up makes it more responsive to a wake and minimises power usage if on battery.

Default functionality is left as before. Fast connect is activated using the setFastConnectMode(true) call. The channel and mac address are retrieved automatically when required.

Changes have been made in development branch