### PR TITLE
Use constrain properly

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2070,8 +2070,7 @@ void WiFiManager::setConnectTimeout(unsigned long seconds) {
  * @param {[type]} uint8_t numRetries [description]
  */
 void WiFiManager::setConnectRetries(uint8_t numRetries){
-  _connectRetries = numRetries;
-  constrain(_connectRetries,1,10);
+  _connectRetries = constrain(numRetries,1,10);
 }
 
 /**


### PR DESCRIPTION
As written, the way constrain is used has no effect/unintended effect and will generate the following warnings:

```
warning: second operand of conditional expression has no effect [-Wunused-value]
warning: third operand of conditional expression has no effect [-Wunused-value]
```

This change addresses those warnings and corrects the behavior.
