### PR TITLE
Fix. The library is not assembled under ESP8266

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3167,7 +3167,7 @@ bool WiFiManager::WiFiSetCountry(){
   */
 
 
-  esp_err_t ret = false;
+  bool ret = false;
   // ret = esp_wifi_set_bandwidth(WIFI_IF_AP,WIFI_BW_HT20); // WIFI_BW_HT40
   #ifdef ESP32
   // @todo check if wifi is init, no idea how, doesnt seem to be exposed atm ( might be now! )


### PR DESCRIPTION
Fix [commit](https://github.com/tzapu/WiFiManager/commit/e071e3ad8fb799044589643b1f355ef750485599). The library is not assembled under esp8266.