### PR TITLE
Support callbacks when waiting on WiFi connection and when in AP mode

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -349,9 +349,6 @@ int WiFiManager::connectWifi(String ssid, String pass) {
 }
 
 uint8_t WiFiManager::waitForConnectResult() {
-  if (_connectTimeout == 0) {
-    return WiFi.waitForConnectResult();
-  } else {
     DEBUG_WM (F("Waiting for connection result with time out"));
     unsigned long start = millis();
     boolean keepConnecting = true;
@@ -369,7 +366,6 @@ uint8_t WiFiManager::waitForConnectResult() {
     }
     return status;
   }
-}
 
 void WiFiManager::startWPS() {
   DEBUG_WM(F("START WPS"));

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -41,7 +41,7 @@ const char HTTP_END[] PROGMEM             = "</div></body></html>";
 
 class WiFiManagerParameter {
   public:
-    /** 
+    /**
         Create custom parameters that can be added to the WiFiManager setup web page
         @id is used for HTTP queries and must not contain spaces nor other special characters
     */
@@ -107,6 +107,8 @@ class WiFiManager
     void          setAPCallback( void (*func)(WiFiManager*) );
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
+    //called when waiting for WiFi configuration
+    void          setConfigWaitCallback( void (*func)(void) );
     //called when waiting for WiFi connection
     void          setConnectionWaitCallback( void (*func)(void) );
     //adds a custom parameter, returns false on failure
@@ -185,6 +187,7 @@ class WiFiManager
 
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
+    void (*_configWaitCallback)(void) = NULL;
     void (*_connectionWaitCallback)(void) = NULL;
 
     void delayWithCallback(unsigned long, void (*func)(void));

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -135,7 +135,7 @@ class WiFiManager
     String        _ssid                   = "";
     String        _pass                   = "";
     unsigned long _configPortalTimeout    = 0;
-    unsigned long _connectTimeout         = 0;
+    unsigned long _connectTimeout         = 60000;
     unsigned long _configPortalStart      = 0;
 
     IPAddress     _ap_static_ip;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -107,6 +107,8 @@ class WiFiManager
     void          setAPCallback( void (*func)(WiFiManager*) );
     //called when settings have been changed and connection was successful
     void          setSaveConfigCallback( void (*func)(void) );
+    //called when waiting for WiFi connection
+    void          setConnectionWaitCallback( void (*func)(void) );
     //adds a custom parameter, returns false on failure
     bool          addParameter(WiFiManagerParameter *p);
     //if this is set, it will exit after config, even if connection is unsuccessful.
@@ -183,6 +185,9 @@ class WiFiManager
 
     void (*_apcallback)(WiFiManager*) = NULL;
     void (*_savecallback)(void) = NULL;
+    void (*_connectionWaitCallback)(void) = NULL;
+
+    void delayWithCallback(unsigned long, void (*func)(void));
 
     int                    _max_params;
     WiFiManagerParameter** _params;


### PR DESCRIPTION
This PR adds 2 configurable callbacks to allow status light update.  E.g., quick flashing during WiFi connection and slow flashing when the board is in AP mode waiting for WiFi configurations.  

Two public methods are added:

1. `setConnectionWaitCallback()`.
This function sets a callback that is invoked periodically when waiting for a WiFi connection.  Two changes are made to support this:
    1. Don't use the blocking `WiFi.waitForConnectResult()`.  Instead, setting the default connection timeout to 60 seconds, which is the same as the default timeout for `WiFi.waitForConnectResult()`.
    2. Change all blocking `delay` calls to non-blocking `while` loop and time check.  This allows the callback to be used for pin update.

2. `setConfigWaitCallback()`.
This function sets a callback that is invoked periodically when the board is in AP mode waiting for a new WiFi configuration.  