### PR TITLE
Add a callback for OTA update

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2630,6 +2630,15 @@ void WiFiManager::setPreSaveConfigCallback( std::function<void()> func ) {
 }
 
 /**
+ * setPreOtaUpdateCallback, set a callback to fire before OTA update
+ * @access public
+ * @param {[type]} void (*func)(void)
+ */
+void WiFiManager::setPreOtaUpdateCallback( std::function<void()> func ) {
+  _preotaupdatecallback = func;
+}
+
+/**
  * set custom head html
  * custom element will be added to head, eg. new style tag etc.
  * @access public
@@ -3587,6 +3596,10 @@ void WiFiManager::handleUpdating(){
 	  if(_debug) Serial.setDebugOutput(true);
     uint32_t maxSketchSpace;
     
+    // Use new callback for before OTA update
+    if (_preotaupdatecallback != NULL) {
+      _preotaupdatecallback();
+    }
     #ifdef ESP8266
     		WiFiUDP::stopAll();
     		maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -220,6 +220,8 @@ class WiFiManager
     //called when saving params-in-wifi or params before anything else happens (eg wifi)
     void          setPreSaveConfigCallback( std::function<void()> func );
 
+    //called just before doing OTA update
+    void          setPreOtaUpdateCallback( std::function<void()> func );
 
     //sets timeout before AP,webserver loop ends and exits even if there has been no setup.
     //useful for devices that failed to connect at some point and got stuck in a webserver loop
@@ -661,6 +663,7 @@ class WiFiManager
     std::function<void()> _presavecallback;
     std::function<void()> _saveparamscallback;
     std::function<void()> _resetcallback;
+    std::function<void()> _preotaupdatecallback;
 
     template <class T>
     auto optionalIPFromString(T *obj, const char *s) -> decltype(  obj->fromString(s)  ) {


### PR DESCRIPTION
Add a callback to be used before the OTA update. The OTA update sometimes can be corrupted because of timer interrupts. The idea is to have a method "setPreOtaUpdateCallback()" to set a user-defined callback. This callback is called just before uploading the new firmware so that the user can disable all the interrupts that may corrupt the OTA update.