### PR TITLE
Change Stream to Print

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -199,7 +199,7 @@ int WiFiManager::getParametersCount() {
 **/
 
 // constructors
-WiFiManager::WiFiManager(Stream& consolePort):_debugPort(consolePort){
+WiFiManager::WiFiManager(Print& consolePort):_debugPort(consolePort){
   WiFiManagerInit();
 }
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -164,7 +164,7 @@ class WiFiManagerParameter {
 class WiFiManager
 {
   public:
-    WiFiManager(Stream& consolePort);
+    WiFiManager(Print& consolePort);
     WiFiManager();
     ~WiFiManager();
     void WiFiManagerInit();
@@ -668,9 +668,9 @@ class WiFiManager
 
     // @todo use DEBUG_ESP_PORT ?
     #ifdef WM_DEBUG_PORT
-    Stream& _debugPort = WM_DEBUG_PORT;
+    Print& _debugPort = WM_DEBUG_PORT;
     #else
-    Stream& _debugPort = Serial; // debug output stream ref
+    Print& _debugPort = Serial; // debug output stream ref
     #endif
 
     template <typename Generic>


### PR DESCRIPTION
WifiManager does not use any `Stream` functionality for `_debugPort`; change the declaration of `_debugPort` so that it is more easily used by other implementations.

Personally, I use a ring buffer that implements Print but not Stream for reading.