### PR TITLE
Add parameter to let the portals keep running in background.

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -313,9 +313,7 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
           DEBUG_WM(DEBUG_DEV,F("hostname: STA: "),getWiFiHostname());
         #endif
       }
-      if (_configPortalIsBlocking || !_shouldRunNonblockingAfterConnection) {
-        return true; // connected success
-      }
+      return true; // connected success
     }
 
     #ifdef WM_DEBUG_LEVEL

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -329,7 +329,9 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
           DEBUG_WM(DEBUG_DEV,F("hostname: STA: "),getWiFiHostname());
         #endif
       }
-      return true; // connected success
+      if (_configPortalIsBlocking || !_shouldRunNonblockingAfterConnection) {
+        return true; // connected success
+      }
     }
 
     #ifdef WM_DEBUG_LEVEL
@@ -805,7 +807,9 @@ uint8_t WiFiManager::processConfigPortal(){
           if ( _savewificallback != NULL) {
             _savewificallback();
           }
-          shutdownConfigPortal();
+          if (_configPortalIsBlocking || !_shouldRunNonblockingAfterConnection) {
+            shutdownConfigPortal();
+          }
           if(!_connectonsave) return WL_IDLE_STATUS;
           return WL_CONNECTED; // CONNECT SUCCESS
         }
@@ -2575,6 +2579,17 @@ void WiFiManager::setMinimumSignalQuality(int quality) {
  */
 void WiFiManager::setBreakAfterConfig(boolean shouldBreak) {
   _shouldBreakAfterConfig = shouldBreak;
+}
+
+/**
+ * If this is set and the the portal is non-blocking, the portals will
+ * start up even on successful autoconnect and won't shutdown after new
+ * successful connection.
+ * @access public
+ * @param boolean keepRunning
+ */
+void WiFiManager::setRunNonblockingAfterConnection(boolean keepRunning) {
+  _shouldRunNonblockingAfterConnection = keepRunning;
 }
 
 /**

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -790,6 +790,13 @@ uint8_t WiFiManager::processConfigPortal(){
         DEBUG_WM(DEBUG_VERBOSE,F("No ssid, skipping wifi save"));
         #endif
       }
+      // skip if selected ssid is already active
+      else if (WiFi.SSID().equals(_ssid) && WiFi.isConnected()) {
+        #ifdef WM_DEBUG_LEVEL
+        DEBUG_WM(DEBUG_VERBOSE,F("Already connected to ssid"));
+        #endif
+        return WL_CONNECTED; // CONNECT SUCCESS
+      }
       else{
         // attempt sta connection to submitted _ssid, _pass
         uint8_t res = connectWifi(_ssid, _pass, _connectonsave) == WL_CONNECTED;
@@ -1680,8 +1687,14 @@ void WiFiManager::handleWifiSave() {
   }
 
   //SAVE/connect here
-  _ssid = server->arg(F("s")).c_str();
-  _pass = server->arg(F("p")).c_str();
+  // Only override WiFi with non-empty values
+  if (!server->arg(F("s")).isEmpty()) {
+    _ssid = server->arg(F("s")).c_str();
+    _pass = server->arg(F("p")).c_str();
+  } else {
+    _ssid = getWiFiSSID();
+    _pass = getWiFiPass();
+  }
 
   if(_paramsInWifi) doParamSave();
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -24,16 +24,7 @@ uint8_t WiFiManager::_lastconxresulttmp = WL_IDLE_STATUS;
  * --------------------------------------------------------------------------------
 **/
 
-WiFiManagerParameter::WiFiManagerParameter() {
-  WiFiManagerParameter("");
-}
-
 WiFiManagerParameter::WiFiManagerParameter(const char *custom) {
-  _id             = NULL;
-  _label          = NULL;
-  _length         = 1;
-  _value          = NULL;
-  _labelPlacement = WFM_LABEL_BEFORE;
   _customHTML     = custom;
 }
 
@@ -61,13 +52,6 @@ void WiFiManagerParameter::init(const char *id, const char *label, const char *d
   setValue(defaultValue,length);
 }
 
-WiFiManagerParameter::~WiFiManagerParameter() {
-  if (_value != NULL) {
-    delete[] _value;
-  }
-  _length=0; // setting length 0, ideally the entire parameter should be removed, or added to wifimanager scope so it follows
-}
-
 // WiFiManagerParameter& WiFiManagerParameter::operator=(const WiFiManagerParameter& rhs){
 //   Serial.println("copy assignment op called");
 //   (*this->_value) = (*rhs._value);
@@ -87,16 +71,16 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
   // }
 
   _length = length;
-  _value  = new char[_length + 1]; 
-  memset(_value, 0, _length + 1); // explicit null
+  _value  = std::make_unique<char[]>(_length + 1);
+  memset(_value.get(), 0, _length + 1); // explicit null
   
   if (defaultValue != NULL) {
-    strncpy(_value, defaultValue, _length);
+    strncpy(_value.get(), defaultValue, _length);
   }
 }
 const char* WiFiManagerParameter::getValue() const {
   // Serial.println(printf("Address of _value is %p\n", (void *)_value)); 
-  return _value;
+  return _value.get();
 }
 const char* WiFiManagerParameter::getID() const {
   return _id;
@@ -1805,7 +1789,7 @@ void WiFiManager::doParamSave(){
       }
 
       //store it in params array
-      value.toCharArray(_params[i]->_value, _params[i]->_length+1); // length+1 null terminated
+      value.toCharArray(_params[i]->_value.get(), _params[i]->_length+1); // length+1 null terminated
       #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(DEBUG_VERBOSE,(String)_params[i]->getID() + ":",value);
       #endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -127,14 +127,12 @@ class WiFiManagerParameter {
         Create custom parameters that can be added to the WiFiManager setup web page
         @id is used for HTTP queries and must not contain spaces nor other special characters
     */
-    WiFiManagerParameter();
+    WiFiManagerParameter() = default;
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *label);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
-    ~WiFiManagerParameter();
-    // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
     const char *getID() const;
     const char *getValue() const;
@@ -149,14 +147,13 @@ class WiFiManagerParameter {
     void init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
 
   private:
-    WiFiManagerParameter& operator=(const WiFiManagerParameter&);
-    const char *_id;
-    const char *_label;
-    char       *_value;
-    int         _length;
-    int         _labelPlacement;
+    const char *_id = nullptr;
+    const char *_label = nullptr;
+    std::unique_ptr<char[]> _value;
+    int         _length = 1;
+    int         _labelPlacement = WFM_LABEL_BEFORE;
   protected:
-    const char *_customHTML;
+    const char *_customHTML = "";
     friend class WiFiManager;
 };
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -274,6 +274,11 @@ class WiFiManager
     
     //if this is set, it will exit after config, even if connection is unsuccessful.
     void          setBreakAfterConfig(boolean shouldBreak);
+
+    // if this is set and the the portal is non-blocking, the portals will
+    // start up even on successful autoconnect and won't shutdown after new
+    // successful connection.
+    void          setRunNonblockingAfterConnection(boolean keepRunning); // default false
     
     // if this is set, portal will be blocking and wait until save or exit, 
     // is false user must manually `process()` to handle config portal,
@@ -475,6 +480,7 @@ class WiFiManager
     boolean       _removeDuplicateAPs     = true;  // remove dup aps from wifiscan
     boolean       _showPassword           = false; // show or hide saved password on wifi form, might be a security issue!
     boolean       _shouldBreakAfterConfig = false; // stop configportal on save failure
+    boolean       _shouldRunNonblockingAfterConnection = false; // keeping running the portal if its non-blocking after connections.
     boolean       _configPortalIsBlocking = true;  // configportal enters blocking loop 
     boolean       _enableCaptivePortal    = true;  // enable captive portal redirection
     boolean       _userpersistent         = true;  // users preffered persistence to restore


### PR DESCRIPTION
This is a really simple mod I made to support using this project both for it's Wifi management, and also as a general configuration page. To do this I run the class in non-blocking mode, and I want the config portal to keep running even after the WiFi connection completes successfully. I also made the corresponding issue: https://github.com/tzapu/WiFiManager/issues/1327 .
