### PR TITLE
Enable Portal Timeout in not Blocking Portal

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -756,6 +756,10 @@ boolean WiFiManager::process(){
     #if defined(WM_MDNS) && defined(ESP8266)
     MDNS.update();
     #endif
+	
+    if(configPortalActive && !_configPortalIsBlocking){
+      if(configPortalHasTimeout()) shutdownConfigPortal();
+    }
 
     if(webPortalActive || (configPortalActive && !_configPortalIsBlocking)){
         uint8_t state = processConfigPortal();


### PR DESCRIPTION
Notice that if we set the _setConfigPortalTimeout( **60** )_ and _setConfigPortalBlocking( **false** )_ we got the first message 
"*wm:[2] Portal Timeout In 60 seconds" but nothing after that. 

This PR is calling the handling for the timeout inside of the process function, in other to utilize the timeout mechanism 

Tested with ESP8266