### PR TITLE
Move WiFiManagerParameter to use a smart pointer and add copy/move constructors

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -24,17 +24,12 @@ uint8_t WiFiManager::_lastconxresulttmp = WL_IDLE_STATUS;
  * --------------------------------------------------------------------------------
 **/
 
-WiFiManagerParameter::WiFiManagerParameter() {
-  WiFiManagerParameter("");
+WiFiManagerParameter::WiFiManagerParameter(const char *custom) {
+  _customHTML     = custom;
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *custom) {
-  _id             = NULL;
-  _label          = NULL;
-  _length         = 1;
-  _value          = NULL;
-  _labelPlacement = WFM_LABEL_BEFORE;
-  _customHTML     = custom;
+WiFiManagerParameter::WiFiManagerParameter(const WiFiManagerParameter& other) {
+  init(other._id, other._label, other.getValue(), other._length, other._customHTML, other._labelPlacement);
 }
 
 WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label) {
@@ -53,19 +48,17 @@ WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, co
   init(id, label, defaultValue, length, custom, labelPlacement);
 }
 
+WiFiManagerParameter& WiFiManagerParameter::operator=(const WiFiManagerParameter& rhs){
+  init(rhs._id, rhs._label, rhs.getValue(), rhs._length, rhs._customHTML, rhs._labelPlacement);
+  return *this;
+}
+
 void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement) {
   _id             = id;
   _label          = label;
   _labelPlacement = labelPlacement;
   _customHTML     = custom;
   setValue(defaultValue,length);
-}
-
-WiFiManagerParameter::~WiFiManagerParameter() {
-  if (_value != NULL) {
-    delete[] _value;
-  }
-  _length=0; // setting length 0, ideally the entire parameter should be removed, or added to wifimanager scope so it follows
 }
 
 // WiFiManagerParameter& WiFiManagerParameter::operator=(const WiFiManagerParameter& rhs){
@@ -87,16 +80,16 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
   // }
 
   _length = length;
-  _value  = new char[_length + 1]; 
-  memset(_value, 0, _length + 1); // explicit null
+  _value  = std::make_unique<char[]>(_length + 1);
+  memset(_value.get(), 0, _length + 1); // explicit null
   
   if (defaultValue != NULL) {
-    strncpy(_value, defaultValue, _length);
+    strncpy(_value.get(), defaultValue, _length);
   }
 }
 const char* WiFiManagerParameter::getValue() const {
   // Serial.println(printf("Address of _value is %p\n", (void *)_value)); 
-  return _value;
+  return _value.get();
 }
 const char* WiFiManagerParameter::getID() const {
   return _id;
@@ -1803,7 +1796,7 @@ void WiFiManager::doParamSave(){
       }
 
       //store it in params array
-      value.toCharArray(_params[i]->_value, _params[i]->_length+1); // length+1 null terminated
+      value.toCharArray(_params[i]->_value.get(), _params[i]->_length+1); // length+1 null terminated
       #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(DEBUG_VERBOSE,(String)_params[i]->getID() + ":",value);
       #endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -127,14 +127,16 @@ class WiFiManagerParameter {
         Create custom parameters that can be added to the WiFiManager setup web page
         @id is used for HTTP queries and must not contain spaces nor other special characters
     */
-    WiFiManagerParameter();
+    WiFiManagerParameter() = default;
+    WiFiManagerParameter(WiFiManagerParameter&& other) = default;
+    WiFiManagerParameter(const WiFiManagerParameter& other);
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *label);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
-    ~WiFiManagerParameter();
-    // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
+
+    WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
     const char *getID() const;
     const char *getValue() const;
@@ -149,14 +151,13 @@ class WiFiManagerParameter {
     void init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
 
   private:
-    WiFiManagerParameter& operator=(const WiFiManagerParameter&);
-    const char *_id;
-    const char *_label;
-    char       *_value;
-    int         _length;
-    int         _labelPlacement;
+    const char             *_id = nullptr;
+    const char             *_label = nullptr;
+    std::unique_ptr<char[]> _value;
+    int                     _length = 1;
+    int                     _labelPlacement = WFM_LABEL_BEFORE;
   protected:
-    const char *_customHTML;
+    const char             *_customHTML = "";
     friend class WiFiManager;
 };
 


### PR DESCRIPTION
This is to address https://github.com/tzapu/WiFiManager/issues/1341 and https://github.com/tzapu/WiFiManager/issues/1050

These changes should have no affect on the functionality except to slightly simplify the class, and add the additional copy/move functions.

Feel free to use this as a starting point if there are stylistic inconsistencies.