### PR TITLE
Add softAP client connect/disconnect callbacks

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -729,6 +729,22 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
 
   while(1){
 
+    //check if client connected to softap, for callback
+    if (WiFi_softap_num_stations() > 0 && _clientConn == false) {
+    _clientConn = true;
+		  if ( _clientconcallback != NULL) {
+			  _clientconcallback();
+		  }
+   }
+
+    //check if client disconnected from softap, for callback
+    if (WiFi_softap_num_stations() == 0 && _clientConn == true) {
+      _clientConn = false;
+		  if ( _clientdisconcallback != NULL) {
+	  		_clientdisconcallback();
+	  	}  
+    
+    }
     // if timed out or abort, break
     if(configPortalHasTimeout() || abort){
       #ifdef WM_DEBUG_LEVEL
@@ -2685,6 +2701,24 @@ void WiFiManager::setPreSaveConfigCallback( std::function<void()> func ) {
  */
 void WiFiManager::setPreOtaUpdateCallback( std::function<void()> func ) {
   _preotaupdatecallback = func;
+}
+
+/**
+ * setClientConnectedCallback, set a callback when client connects to softap
+ * @access public 
+ * @param {[type]} void (*func)(void)
+ */
+void WiFiManager::setClientConnectedCallback( std::function<void()> func ) {
+  _clientconcallback = func;
+}
+
+/**
+ * setClientDisconnectedCallback, set a callback when client disconnects from softap
+ * @access public 
+ * @param {[type]} void (*func)(void)
+ */
+void WiFiManager::setClientDisconnectedCallback( std::function<void()> func ) {
+  _clientdisconcallback = func;
 }
 
 /**

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -229,6 +229,12 @@ class WiFiManager
 
     // SET CALLBACKS
 
+    //called when client connects to softap
+    void          setClientConnectedCallback( std::function<void()> func );
+	
+	//called when client disconnects from softap
+    void          setClientDisconnectedCallback( std::function<void()> func );
+
     //called after AP mode and config portal has started
     void          setAPCallback( std::function<void(WiFiManager*)> func );
 
@@ -506,6 +512,7 @@ class WiFiManager
     boolean       _showBack               = false; // show back button
     boolean       _enableConfigPortal     = true;  // use config portal if autoconnect failed
     String        _hostname               = "";    // hostname for esp8266 for dhcp, and or MDNS
+    boolean       _clientConn             = false; // for client connect and disconnect callbacks
 
     const char*   _customHeadElement      = ""; // store custom head element html from user
     String        _bodyClass              = ""; // class to add to body
@@ -717,6 +724,8 @@ class WiFiManager
     std::function<void()> _saveparamscallback;
     std::function<void()> _resetcallback;
     std::function<void()> _preotaupdatecallback;
+    std::function<void()> _clientconcallback;
+    std::function<void()> _clientdisconcallback;
 
     template <class T>
     auto optionalIPFromString(T *obj, const char *s) -> decltype(  obj->fromString(s)  ) {

--- a/keywords.txt
+++ b/keywords.txt
@@ -24,6 +24,8 @@ setDebugOutput	KEYWORD2
 setMinimumSignalQuality KEYWORD2
 setAPStaticIPConfig	KEYWORD2
 setSTAStaticIPConfig KEYWORD2
+setClientConnectedCallback	KEYWORD2
+setClientDisconnectedCallback	KEYWORD2
 setAPCallback	KEYWORD2
 setSaveConfigCallback KEYWORD2
 addParameter KEYWORD2


### PR DESCRIPTION
Add softAP client connect/disconnect callbacks. Can be useful when you want to do something when a client connects/disconnects to/from a softAP. For example, change led color, display a message on display, etc...