### PR TITLE
WM_VERSION_STR correction (used in About section)

### DIFF
--- a/strings_en.h
+++ b/strings_en.h
@@ -17,7 +17,7 @@
 #ifndef WIFI_MANAGER_OVERRIDE_STRINGS
 // !!! ABOVE WILL NOT WORK if you define in your sketch, must be build flag, if anyone one knows how to order includes to be able to do this it would be neat.. I have seen it done..
 
-const char WM_VERSION_STR[] PROGMEM = "v1.0.11-beta";
+const char WM_VERSION_STR[] PROGMEM = "v2.0.11-beta";
 
 const char HTTP_HEAD_START[]       PROGMEM = "<!DOCTYPE html>"
 "<html lang='en'><head>"


### PR DESCRIPTION
From  "v1.0.11-beta" to "v2.0.11-beta"

I think the major version was forgotten to be updated.