### PR TITLE
Escape single quotes in htmlEntities()

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3363,6 +3363,7 @@ String WiFiManager::htmlEntities(String str, bool whitespace) {
   str.replace("&","&amp;");
   str.replace("<","&lt;");
   str.replace(">","&gt;");
+  str.replace("'","&#39;");
   if(whitespace) str.replace(" ","&#160;");
   // str.replace("-","&ndash;");
   // str.replace("\"","&quot;");


### PR DESCRIPTION
This should allow SSIDs that contain single quotes to populate data-ssid correctly. Without this patch, clicking on an SSID containing a single quote will either:
* Not use the whole SSID, in cases where there's text before the quote:
  `foo'bar` will appear in the SSID box as just `foo`
* Fall back to innerText, in cases where the quote is the first character in the SSID:
  `'); DROP TABLE WIFI; --` will appear in the SSID box as a version that has spaces converted to non-breaking spaces, causing the connection to eventually fail with WL_NO_SSID_AVAIL.

Fixes #1412 