### PR TITLE
Avoid String addition when dealing with compile time

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2209,7 +2209,7 @@ String WiFiManager::getInfoData(String id){
   }
   else if(id==F("aboutdate")){
     p = FPSTR(HTTP_INFO_aboutdate);
-    p.replace(FPSTR(T_1),String(__DATE__) + " " + String(__TIME__));
+    p.replace(FPSTR(T_1),String(__DATE__ " " __TIME__));
   }
   return p;
 }


### PR DESCRIPTION
Avoid constructing two String objects and adding them together. Just concatenate c-strings.