### PR TITLE
Change test action to install from local directory

### DIFF
--- a/.github/workflows/compile_examples.yaml
+++ b/.github/workflows/compile_examples.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Install 3rd party dependecies
         run: |
           pio lib -g install \
-          https://github.com/tzapu/WiFiManager \
+          file://. \
           https://github.com/bblanchon/ArduinoJson \
           https://github.com/knolleary/pubsubclient
 

--- a/.github/workflows/compile_examples.yaml
+++ b/.github/workflows/compile_examples.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Install 3rd party dependecies
       run: | 
         pio lib -g install \
-        https://github.com/tzapu/WiFiManager \
+        file://. \
         https://github.com/bblanchon/ArduinoJson \
         https://github.com/knolleary/pubsubclient
         


### PR DESCRIPTION
This fixes the "compile examples" GitHub action in order to use the incoming code rather than the existing master at tzapu/WiFiManager

This fixes #1472 