### PR TITLE
Support for WifiManager as ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(
+                       SRCS "WiFiManager.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES arduino
+)
+
+project(WiFiManager)


### PR DESCRIPTION
Enables support for WifiManager as an ESP-IDF component.  ESP-IDF is a popular development framework for ESP32 chips.

This file is based on the CMakeLists.txt file from the popular Adafruit-GFX-Library library.