### PR TITLE
WPA2 Enterprise PEAP support

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1958,7 +1958,6 @@ void WiFiManager::handleWifiSave() {
                   #ifdef WM_DEBUG_LEVEL
                   DEBUG_WM(DEBUG_DEV,F("cannot write to nvs flash"));
                   #endif
-                      Serial.printf("bruh");
                }
 
               nvs_set_str(handle, "wm.pass", _pass.c_str());

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -514,8 +514,10 @@ class WiFiManager
     String        _apName                 = "no-net";
     String        _apPassword             = "";
     String        _ssid                   = ""; // var temp ssid
+    String        _user                   = ""; // var temp username
     String        _pass                   = ""; // var temp psk
     String        _defaultssid            = ""; // preload ssid
+    String        _defaultuser            = ""; // preload user
     String        _defaultpass            = ""; // preload pass
 
     // options flags
@@ -623,9 +625,11 @@ class WiFiManager
     void          setupDNSD();
     void          setupHTTPServer();
 
+    uint8_t       connectWifi(String ssid, String user, String pass, bool connect = true);
     uint8_t       connectWifi(String ssid, String pass, bool connect = true);
     bool          setSTAConfig();
     bool          wifiConnectDefault();
+    bool          wifiConnectNew(String ssid, String user, String pass,bool connect = true);
     bool          wifiConnectNew(String ssid, String pass,bool connect = true);
 
     uint8_t       waitForConnectResult();

--- a/strings_en.h
+++ b/strings_en.h
@@ -30,7 +30,11 @@ const char HTTP_SCRIPT[]           PROGMEM = "<script>function c(l){"
 "document.getElementById('s').value=l.getAttribute('data-ssid')||l.innerText||l.textContent;"
 "p = l.nextElementSibling.classList.contains('l');"
 "document.getElementById('p').disabled = !p;"
-"if(p)document.getElementById('p').focus();};"
+"if(p)document.getElementById('p').focus();"
+ "u = l.nextElementSibling.classList.contains('WPA2_ENTERPRISE');"
+"document.getElementById('u').style.display = u?'block':'none';"
+"document.getElementById('u-label').style.display = u?'block':'none';"
+"if(u)document.getElementById('u').focus()};"
 "function f() {var x = document.getElementById('p');x.type==='password'?x.type='text':x.type='password';}"
 "</script>"; // @todo add button states, disable on click , show ack , spinner etc
 
@@ -54,13 +58,13 @@ const char * const HTTP_PORTAL_MENU[] PROGMEM = {
 
 // const char HTTP_PORTAL_OPTIONS[]   PROGMEM = strcat(HTTP_PORTAL_MENU[0] , HTTP_PORTAL_MENU[3] , HTTP_PORTAL_MENU[7]);
 const char HTTP_PORTAL_OPTIONS[]   PROGMEM = "";
-const char HTTP_ITEM_QI[]          PROGMEM = "<div role='img' aria-label='{r}%' title='{r}%' class='q q-{q} {i} {h}'></div>"; // rssi icons
+const char HTTP_ITEM_QI[]          PROGMEM = "<div role='img' aria-label='{r}%' title='{r}%' class='q q-{q} {i} {h} {e}'></div>"; // rssi icons
 const char HTTP_ITEM_QP[]          PROGMEM = "<div class='q {h}'>{r}%</div>"; // rssi percentage {h} = hidden showperc pref
 const char HTTP_ITEM[]             PROGMEM = "<div><a href='#p' onclick='c(this)' data-ssid='{V}'>{v}</a>{qi}{qp}</div>"; // {q} = HTTP_ITEM_QI, {r} = HTTP_ITEM_QP
 // const char HTTP_ITEM[]            PROGMEM = "<div><a href='#p' onclick='c(this)'>{v}</a> {R} {r}% {q} {e}</div>"; // test all tokens
 
 const char HTTP_FORM_START[]       PROGMEM = "<form method='POST' action='{v}'>";
-const char HTTP_FORM_WIFI[]        PROGMEM = "<label for='s'>SSID</label><input id='s' name='s' maxlength='32' autocorrect='off' autocapitalize='none' placeholder='{v}'><br/><label for='p'>Password</label><input id='p' name='p' maxlength='64' type='password' placeholder='{p}'><input type='checkbox' onclick='f()'> Show Password";
+const char HTTP_FORM_WIFI[]        PROGMEM = "<label for='s'>SSID</label><input id='s' name='s' maxlength='32' autocorrect='off' autocapitalize='none' placeholder='{v}'><br/><label id='u-label' style='display:none' for='u'>Username</label><input id='u' name='u' maxlength='32' placeholder='Username' style='display:none'/><br/><label for='p'>Password</label><input id='p' name='p' maxlength='64' type='password' placeholder='{p}'><input type='checkbox' onclick='f()'> Show Password";
 const char HTTP_FORM_WIFI_END[]    PROGMEM = "";
 const char HTTP_FORM_STATIC_HEAD[] PROGMEM = "<hr><br/>";
 const char HTTP_FORM_END[]         PROGMEM = "<br/><br/><button type='submit'>Save</button></form>";


### PR DESCRIPTION
Hi,

I'm currently working in an environment where I have to connect the ESP32 to a WPA2 Enterprise network protected with PEAP. Given the nature of such a network, the credentials are used for more than just WiFi. I was hence uncomfortable with configuring my username & password directly on a sketch that I would be sharing, so I decided to use WiFiManager.

The PR contains some code to get WiFiManager working with PEAP-protected networks. Is implementing support for WPA2 Enterprise networks currently on the roadmap?

I had to use my own NVS storage, as it seems like the ESP32 framework doesn't automatically save credentials for anything outside of a typical SSID & Password combo.
