### PR TITLE
Async webserver

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1,7 +1,7 @@
 /**
  * WiFiManager.cpp
  * 
- * WiFiManager, a library for the ESP32/Arduino platform
+ * WiFiManager, a library for the ESP/Arduino platforms
  * for configuration of WiFi credentials using a Captive Portal
  * 
  * @author Creator tzapu

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -1,11 +1,12 @@
 /**
  * WiFiManager.h
  * 
- * WiFiManager, a library for the ESP8266/Arduino platform
+ * WiFiManager, a library for the ESP32/Arduino platform
  * for configuration of WiFi credentials using a Captive Portal
  * 
  * @author Creator tzapu
  * @author tablatronix
+ * @author joba-1 joachim.banzhaf@gmail.com (ESPAsyncWebServer port)
  * @version 0.0.0
  * @license MIT
  */
@@ -91,7 +92,7 @@
 
     #ifndef WEBSERVER_H
         #ifdef WM_WEBSERVERSHIM
-            #include <WebServer.h>
+            #include <ESPAsyncWebServer.h>
         #else
             #include <ESP8266WebServer.h>
             // Forthcoming official ? probably never happening
@@ -484,7 +485,7 @@ class WiFiManager
     std::unique_ptr<DNSServer>        dnsServer;
 
     #if defined(ESP32) && defined(WM_WEBSERVERSHIM)
-        using WM_WebServer = WebServer;
+        using WM_WebServer = AsyncWebServer;
     #else
         using WM_WebServer = ESP8266WebServer;
     #endif
@@ -639,32 +640,33 @@ class WiFiManager
     void          updateConxResult(uint8_t status);
 
     // webserver handlers
-    void          HTTPSend(String content);
-    void          handleRoot();
-    void          handleWifi(boolean scan);
-    void          handleWifiSave();
-    void          handleInfo();
-    void          handleReset();
-    void          handleNotFound();
-    void          handleExit();
-    void          handleClose();
+    void          HTTPSend(String content, AsyncWebServerRequest *request);
+    void          handleRoot(AsyncWebServerRequest *request);
+    void          handleWifi(AsyncWebServerRequest *request, boolean scan);
+    void          handleWifiSave(AsyncWebServerRequest *request);
+    void          handleInfo(AsyncWebServerRequest *request);
+    void          handleReset(AsyncWebServerRequest *request);
+    void          handleNotFound(AsyncWebServerRequest *request);
+    void          handleExit(AsyncWebServerRequest *request);
+    void          handleClose(AsyncWebServerRequest *request);
     // void          handleErase();
-    void          handleErase(boolean opt);
-    void          handleParam();
-    void          handleWiFiStatus();
-    void          handleRequest();
-    void          handleParamSave();
-    void          doParamSave();
+    void          handleErase(AsyncWebServerRequest *request, boolean opt);
+    void          handleParam(AsyncWebServerRequest *request);
+    void          handleWiFiStatus(AsyncWebServerRequest *request);
+    void          handleRequest(AsyncWebServerRequest *request);
+    void          handleParamSave(AsyncWebServerRequest *request);
+    void          doParamSave(AsyncWebServerRequest *request);
 
-    boolean       captivePortal();
+    boolean       captivePortal(AsyncWebServerRequest *request);
     boolean       configPortalHasTimeout();
     uint8_t       processConfigPortal();
     void          stopCaptivePortal();
+/*
 	// OTA Update handler
-	void          handleUpdate();
-	void          handleUpdating();
-	void          handleUpdateDone();
-
+	void          handleUpdate(AsyncWebServerRequest *request);
+	void          handleUpdating(AsyncWebServerRequest *request);
+	void          handleUpdateDone(AsyncWebServerRequest *request);
+*/
 
     // wifi platform abstractions
     bool          WiFi_Mode(WiFiMode_t m);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -1,7 +1,7 @@
 /**
  * WiFiManager.h
  * 
- * WiFiManager, a library for the ESP32/Arduino platform
+ * WiFiManager, a library for the ESP/Arduino platforms
  * for configuration of WiFi credentials using a Captive Portal
  * 
  * @author Creator tzapu
@@ -72,7 +72,7 @@
       #include "user_interface.h"
     }
     #include <ESP8266WiFi.h>
-    #include <ESP8266WebServer.h>
+    #include <ESPAsyncWebServer.h>
 
     #ifdef WM_MDNS
         #include <ESP8266mDNS.h>
@@ -484,11 +484,7 @@ class WiFiManager
 
     std::unique_ptr<DNSServer>        dnsServer;
 
-    #if defined(ESP32) && defined(WM_WEBSERVERSHIM)
-        using WM_WebServer = AsyncWebServer;
-    #else
-        using WM_WebServer = ESP8266WebServer;
-    #endif
+    using WM_WebServer = AsyncWebServer;
     
     std::unique_ptr<WM_WebServer> server;
 


### PR DESCRIPTION
Not meant for merge, just as a heads up. Probably better to allow a choice...

* Basic functionality works on ESP32 - only faster.
* OTA is disabled, hints to make it work welcome.
* Compiles for ESP8266.

tested with 

```cpp
#include <Arduino.h>

// include WiFiManager before ESPAsyncWebServer!
#include <WiFiManager.h>
#include <ESPAsyncWebServer.h>

AsyncWebServer web_server(80);

void manageWifi() {
  const char *host;
  #if defined(ESP32)
    host = WiFi.getHostname();
  #else
    host = WiFi.hostname().c_str();
  #endif
  WiFiManager wm;
  // wm.resetSettings();
  if (!wm.autoConnect(host, host)) {
    ESP.restart();
    while (true)
      ;
  }
}

void setup() {
  Serial.begin(115200);
  Serial.println("\nWifi");

  if (!WiFi.mode(WIFI_STA)) Serial.println("WiFi.mode(WIFI_STA) failed");
  if (!WiFi.hostname("AsyncWiFiManager")) Serial.println("WiFi.hostname() failed");

  Serial.println("Manager");
  manageWifi();

  Serial.println("Webserver");
  web_server.on("/", []( AsyncWebServerRequest *request ) {
    Serial.println("Serve");
    request->send(200, "text/html", 
      "<html>"
        "<head><title>Woooosh!</title></head>"
        "<body>"
          "<h1>Async WiFiManager Test</h1>"
          "<form method=\"post\" action=\"/wipe\">"
            "<input type=\"submit\" value=\"Wipe Wlan Config\"/>"
          "</form>"
          "<form method=\"post\" action=\"/reset\">"
            "<input type=\"submit\" value=\"Reset\"/>"
          "</form>"
        "</body>"
      "<html>");
  });

  web_server.on("/wipe", HTTP_POST, []( AsyncWebServerRequest *request ) { 
    Serial.println("Wipe");
    WiFiManager wm;
    wm.resetSettings();
    request->redirect("/");
  });

  web_server.on("/reset", HTTP_POST, []( AsyncWebServerRequest *request ) { 
    request->redirect("/");
    Serial.println("Reset");
    Serial.flush();
    ESP.restart();
  });

  web_server.begin();

  Serial.println("Done");
}

void loop() {
}
```
