### PR TITLE
Update WiFiManager.cpp

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2398,7 +2398,13 @@ boolean WiFiManager::captivePortal() {
   
   if(!_enableCaptivePortal) return false; // skip redirections, @todo maybe allow redirection even when no cp ? might be useful
   
-  String serverLoc =  toStringIp(server->client().localIP());
+  //String serverLoc =  toStringIp(server->client().localIP()); //this appears to be broken and returns a 0.0.0.0
+  String serverLoc;
+  if ((WiFi.status()) != WL_CONNECTED)
+    serverLoc = toStringIp(WiFi.softAPIP());
+  else
+    serverLoc = toStringIp(WiFi.localIP());
+	
   if(_httpPort != 80) serverLoc += ":" + (String)_httpPort; // add port if not default
   bool doredirect = serverLoc != server->hostHeader(); // redirect if hostheader not server ip, prevent redirect loops
   // doredirect = !isIp(server->hostHeader()) // old check


### PR DESCRIPTION
Fixed bug where the CaptivePortal / WebPortal would redirect to 0.0.0.0 instead of the device's IP stemming from an invalid IP being returned by server->client().localIP()