### PR TITLE
Only reconnect if WiFi updated

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1858,6 +1858,7 @@ void WiFiManager::handleWifiSave() {
   else {
     page = getHTTPHead(FPSTR(S_titlewifisaved)); // @token titlewifisaved
     page += FPSTR(HTTP_SAVED);
+    connect = true; //signal ready to connect/reset process in processConfigPortal
   }
 
   if(_showBack) page += FPSTR(HTTP_BACKBTN);
@@ -1869,8 +1870,6 @@ void WiFiManager::handleWifiSave() {
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(DEBUG_DEV,F("Sent wifi save page"));
   #endif
-
-  connect = true; //signal ready to connect/reset process in processConfigPortal
 }
 
 void WiFiManager::handleParamSave() {


### PR DESCRIPTION
If only the parameters have been updated then don't try to reconnect on save. Otherwise `_ssid` and `_pass` are blank (because "placeholder" input attribute is used) and the connection will fail.