### PR TITLE
New function to request the status of the Access Point with a limit uptime setting

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -280,6 +280,8 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
   DEBUG_WM(F("AutoConnect"));
   #endif
 
+  _WifiAP_active = false;
+
   // bool wifiIsSaved = getWiFiIsSaved();
 
   #ifdef ESP32
@@ -572,6 +574,13 @@ void WiFiManager::stopWebPortal() {
   #endif
   webPortalActive = false;
   shutdownConfigPortal();
+}
+
+bool WiFiManager::WifiAP_active(int max_uptime_minutes){
+  if((millis()-_startconn) < (max_uptime_minutes * 60000)){
+    return (_WifiAP_active);
+  }
+  return false;
 }
 
 boolean WiFiManager::configPortalHasTimeout(){
@@ -1329,6 +1338,8 @@ void WiFiManager::handleRoot() {
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(DEBUG_VERBOSE,F("<- HTTP Root"));
   #endif
+
+  _WifiAP_active = true;
   if (captivePortal()) return; // If captive portal redirect instead of displaying the page
   handleRequest();
   String page = getHTTPHead(_title); // @token options @todo replace options with title
@@ -2312,6 +2323,7 @@ void WiFiManager::handleExit() {
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(DEBUG_VERBOSE,F("<- HTTP Exit"));
   #endif
+  _WifiAP_active = false;
   handleRequest();
   String page = getHTTPHead(FPSTR(S_titleexit)); // @token titleexit
   page += FPSTR(S_exiting); // @token exiting
@@ -2440,6 +2452,7 @@ void WiFiManager::stopCaptivePortal(){
 // HTTPD CALLBACK, handle close,  stop captive portal, if not enabled undefined
 void WiFiManager::handleClose(){
   DEBUG_WM(DEBUG_VERBOSE,F("Disabling Captive Portal"));
+  _WifiAP_active = false;
   stopCaptivePortal();
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(DEBUG_VERBOSE,F("<- HTTP close"));

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -463,6 +463,7 @@ bool WiFiManager::setupHostname(bool restart){
 
 // CONFIG PORTAL
 bool WiFiManager::startAP(){
+  _WifiAP_active = true;
   bool ret = true;
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(F("StartAP with SSID: "),_apName);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -487,6 +487,9 @@ class WiFiManager
     // get hostname helper
     String        getWiFiHostname();
 
+    // indicate if AP is currently in use
+    bool          WifiAP_active(int max_uptime_minutes);
+
 
     std::unique_ptr<DNSServer>        dnsServer;
 
@@ -553,6 +556,7 @@ class WiFiManager
                                                    // on some conn failure modes will add delays and many retries to work around esp and ap bugs, ie, anti de-auth protections
                                                    // https://github.com/tzapu/WiFiManager/issues/1067
     bool          _allowExit              = true; // allow exit in nonblocking, else user exit/abort calls will be ignored including cptimeout
+    bool          _WifiAP_active          = false;
 
     #ifdef ESP32
     wifi_event_id_t wm_event_id           = 0;


### PR DESCRIPTION
Changes:
- New private bool: _WifiAP_active => True if the AP is active
- New public function: WifiAP_active(int max_uptime_minutes) => returns True if the AP is active and False if not or if the maximum uptime in minutes has been reached

Background:
Limits the uptime of the AP for battery powered devices in case the Wifi is temporarily not accessible. In the code, the status of the AP can be requested and the device sen to sleep in case the maximum uptime has been exceeded instead of keeping the AP active.