### PR TITLE
Update WiFiManager.cpp

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -812,6 +812,9 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     if(!configPortalActive) break;
 
     yield(); // watchdog
+    #ifdef ESP32
+	delay(0);
+    #endif
   }
 
   #ifdef WM_DEBUG_LEVEL


### PR DESCRIPTION
With ESP32-WROOM-32E-N16, a watchdog reset occurs which is caused by the 'while' loop in the StartConfigPortal function exceeding the watchdog timer in some cases. Adding a delay(0) into this 'while' loop feeds the watchdog and prevents a timeout reset for ESP32.