### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 idf_component_register(
                        SRCS "WiFiManager.cpp"
                        INCLUDE_DIRS "."
-                       REQUIRES arduino
+                       PRIV_REQUIRES arduino
 )
 
 project(WiFiManager)


### PR DESCRIPTION
Change `REQUIRES` to `PRIV_REQUIRES` because the public API of this package does not require users of this package to know about `arduino`. This can cut down on the compile time & search paths (see https://cmake.org/pipermail/cmake/2016-May/063400.html for more details).