### PR TITLE
Limited redirect

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2420,6 +2420,15 @@ boolean WiFiManager::captivePortal() {
   bool doredirect = serverLoc != server->hostHeader(); // redirect if hostheader not server ip, prevent redirect loops
   // doredirect = !isIp(server->hostHeader()) // old check
   
+  //Only redirect the portal detection requests. Avoids overload.
+  doredirect = doredirect 
+                && (server->hostHeader().indexOf("connect")>=0
+                    || server->hostHeader().indexOf("msft")>=0
+                    || server->hostHeader().indexOf("apple")>=0
+                    || server->uri().startsWith("/gen")
+                    || server->uri().indexOf("hostpot")>=0
+                );
+
   if (doredirect) {
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(DEBUG_VERBOSE,F("<- Request redirected to captive portal"));


### PR DESCRIPTION
When I connect to wifimanager from my windows, it generates many requests (eg wpad/wpad.dat, autodiscover, etc.).
All these requests end up being served by wifimanager twice: once for redirect and a second time as 404.
It's often so consuming for asyncweb that the esp32 ends up crashing and my pc disconnected.
It's often better from my mobile where I get less extra requests.

However, I believe we shouldn't redirect these extra requests in the first place. With this change, I see no more crashes nor disconnections.