### PR TITLE
Docs: fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,30 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 :warning: This Documentation is out of date, see notes below
 
-![Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases)
-
-[![Build CI Status](https://github.com/tzapu/WiFiManager/actions/workflows/compile_library.yml/badge.svg)](https://github.com/tzapu/WiFiManager/actions/workflows/compile_library.yml)
-
-[![Build CI Status Examples](https://github.com/tzapu/WiFiManager/actions/workflows/compile_examples.yaml/badge.svg)](https://github.com/tzapu/WiFiManager/actions/workflows/compile_examples.yaml)
+![Release](https://github.com/tzapu/WiFiManager/releases)
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/WiFiManager.svg?)](https://www.ardu-badge.com/WiFiManager)
 
 [![Build with PlatformIO](https://img.shields.io/badge/PlatformIO-Library-orange?)](https://platformio.org/lib/show/567/WiFiManager/installation)
 
-[![ESP8266](https://img.shields.io/badge/ESP-8266-000000.svg?longCache=true&style=flat&colorA=CC101F)](https://www.espressif.com/en/products/socs/esp8266)
+[![Build CI Status](https://github.com/tzapu/WiFiManager/actions/workflows/compile_library.yml/badge.svg)](https://github.com/tzapu/WiFiManager/actions/workflows/compile_library.yml)
 
+[![Build CI Status Examples](https://github.com/tzapu/WiFiManager/actions/workflows/compile_examples.yaml/badge.svg)](https://github.com/tzapu/WiFiManager/actions/workflows/compile_examples.yaml)
+
+
+[![ESP8266](https://img.shields.io/badge/ESP-8266-000000.svg?longCache=true&style=flat&colorA=CC101F)](https://www.espressif.com/en/products/socs/esp8266)
 [![ESP32](https://img.shields.io/badge/ESP-32-000000.svg?longCache=true&style=flat&colorA=CC101F)](https://www.espressif.com/en/products/socs/esp32)
 [![ESP32](https://img.shields.io/badge/ESP-32S2-000000.svg?longCache=true&style=flat&colorA=CC101F)](https://www.espressif.com/en/products/socs/esp32-s2)
 [![ESP32](https://img.shields.io/badge/ESP-32C3-000000.svg?longCache=true&style=flat&colorA=CC101F)](https://www.espressif.com/en/products/socs/esp32-c3)
 
+
+
 Member to Member Support / Chat
 
- [![Join the chat at https://gitter.im/tablatronix/WiFiManager](https://badges.gitter.im/tablatronix/WiFiManager.svg)](https://gitter.im/tablatronix/WiFiManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/tablatronix/WiFiManager](https://badges.gitter.im/tablatronix/WiFiManager.svg)](https://gitter.im/tablatronix/WiFiManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
  
 [![Discord](https://img.shields.io/badge/Discord-WiFiManager-%237289da.svg?logo=discord)](https://discord.gg/nS5WGkaQH5)
+
 The configuration portal is of the captive variety, so on various devices it will present the configuration dialogue as soon as you connect to the created access point.
 
 **This works with the ESP8266 Arduino platform**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 :warning: This Documentation is out of date, see notes below
 
-[Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases) [https://github.com/tzapu/WiFiManager/releases]
+[Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases)](https://github.com/tzapu/WiFiManager/releases)
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/WiFiManager.svg?)](https://www.ardu-badge.com/WiFiManager)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 :warning: This Documentation is out of date, see notes below
 
-[![Release](https://github.com/tzapu/WiFiManager/releases)
+[Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases) [https://github.com/tzapu/WiFiManager/releases]
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/WiFiManager.svg?)](https://www.ardu-badge.com/WiFiManager)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 :warning: This Documentation is out of date, see notes below
 
-![Release](https://github.com/tzapu/WiFiManager/releases)
+[![Release](https://github.com/tzapu/WiFiManager/releases)
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/WiFiManager.svg?)](https://www.ardu-badge.com/WiFiManager)
 
@@ -23,7 +23,8 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 
 
-Member to Member Support / Chat
+
+**Member to Member Support / Chat**
 
 [![Join the chat at https://gitter.im/tablatronix/WiFiManager](https://badges.gitter.im/tablatronix/WiFiManager.svg)](https://gitter.im/tablatronix/WiFiManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Espressif ESPx WiFi Connection manager with fallback web configuration portal
 
 :warning: This Documentation is out of date, see notes below
 
-[Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases)](https://github.com/tzapu/WiFiManager/releases)
+[![Release](https://img.shields.io/github/v/release/tzapu/WiFiManager?include_prereleases)](https://github.com/tzapu/WiFiManager/releases)
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/WiFiManager.svg?)](https://www.ardu-badge.com/WiFiManager)
 


### PR DESCRIPTION
linked the releases badge to the [https://github.com/tzapu/WiFiManager/releases]
formatted the esp-board badges,
formatted the chat support badges.

![image](https://github.com/tzapu/WiFiManager/assets/72402072/e58651da-1ed9-4ed0-a63f-6d45e9dde401)
