### PR TITLE
Add virtual for getValue (for override getValue)

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -211,7 +211,7 @@ class WiFiManagerParameter {
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
     const char *getID() const;
-    const char *getValue() const;
+    virtual const char *getValue() const;
     const char *getLabel() const;
     const char *getPlaceholder() const; // @deprecated, use getLabel
     int         getValueLength() const;


### PR DESCRIPTION
Hi
Currently there is no way to create a dynamic checkbox. I wrote the code for this:
```C++
class CheckboxParameter : public WiFiManagerParameter {
public:
  const char* checked = "type=\"checkbox\" checked";
  const char* noChecked = "type=\"checkbox\"";
  const char* trueVal = "T";

  CheckboxParameter(const char* id, const char* label, bool value): WiFiManagerParameter("") {
    init(id, label, value ? trueVal : "0", 1, "", WFM_LABEL_BEFORE);
  }

  const char* getValue() const override {
    return trueVal;
  }

  const char* getCustomHTML() const override {
    return strcmp(WiFiManagerParameter::getValue(), trueVal) == 0 ? checked : noChecked;
  }

  bool getCheckboxValue() {
    return strcmp(WiFiManagerParameter::getValue(), trueVal) == 0 ? true : false;
  }
};
```

But for it to work, getValue must be overridden.

https://github.com/tzapu/WiFiManager/issues/1654
https://github.com/tzapu/WiFiManager/issues/1639
https://github.com/tzapu/WiFiManager/issues/1111