### PR TITLE
Faster connection

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1130,8 +1130,7 @@ bool WiFiManager::wifiConnectDefault(){
   DEBUG_WM(WM_DEBUG_DEV,F("Using Password:"),WiFi_psk(true));
   #endif
 
-  ret = WiFi_enableSTA(true,storeSTAmode);
-  delay(500); // THIS DELAY ?
+  ret = WiFi.mode(WIFI_STA);
 
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(WM_DEBUG_DEV,F("Mode after delay: "),getModeString(WiFi.getMode()));


### PR DESCRIPTION
As described in https://github.com/tzapu/WiFiManager/issues/1342#issuecomment-1861246376, the removal of the delay provides a significant improvement of connection time from 700ms to 200ms.
This is especially important for battery powered devices.