### PR TITLE
Make WiFiManagerParameter destructor virtual

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -207,7 +207,7 @@ class WiFiManagerParameter {
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom);
     WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
-    ~WiFiManagerParameter();
+    virtual ~WiFiManagerParameter();
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
     const char *getID() const;


### PR DESCRIPTION
If a instance of WiFiManagerParameter is created by `new` and deleted by `delete`, a compiler warning is issued.

```
src/settings/SettingsController.cpp:78:67: warning: deleting object of polymorphic class type 'WiFiManagerParameter' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
   78 |   for (WiFiManagerParameter* p : this->wifi_settings->parameters) delete p;
```

The destructor should be virtual, because the class can be extended.