### PR TITLE
Custom HTML at the Top of "<body>"

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1288,6 +1288,7 @@ String WiFiManager::getHTTPHead(String title){
     page += FPSTR(HTTP_HEAD_END);
   } 
 
+  page += _customTopBodyElement;
   return page;
 }
 
@@ -2887,6 +2888,16 @@ void WiFiManager::setConfigPortalTimeoutCallback( std::function<void()> func ) {
  */
 void WiFiManager::setCustomHeadElement(const char* html) {
   _customHeadElement = html;
+}
+
+/**
+ * set custom top body html
+ * custom element will be added to shortly after body tag opened, eg. to show a logo etc.
+ * @access public
+ * @param char element
+ */
+void WiFiManager::setCustomTopBodyElement(const char* html) {
+  _customTopBodyElement = html;
 }
 
 /**

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -374,6 +374,9 @@ class WiFiManager
     //add custom html at inside <head> for all pages
     void          setCustomHeadElement(const char* html);
 
+    //add custom html at start of <body> for all pages
+    void          setCustomTopBodyElement(const char* html);
+
     //if this is set, customise style
     void          setCustomMenuHTML(const char* html);
 
@@ -596,8 +599,9 @@ class WiFiManager
     boolean       _disableConfigPortal    = true;  // FOR autoconnect - stop config portal if cp wifi save
     String        _hostname               = "";    // hostname for esp8266 for dhcp, and or MDNS
 
-    const char*   _customHeadElement      = ""; // store custom head element html from user isnide <head>
-    const char*   _customMenuHTML         = ""; // store custom head element html from user inside <>
+    const char*   _customHeadElement      = ""; // store custom head element html from user inside <head>
+    const char*   _customTopBodyElement   = ""; // store custom top body element html from user inside <body>
+    const char*   _customMenuHTML         = ""; // store custom menu html from user
     String        _bodyClass              = ""; // class to add to body
     String        _title                  = FPSTR(S_brand); // app title -  default WiFiManager
 


### PR DESCRIPTION
Added setCustomTopBodyElement allowing to define custom HTML to be added at the top of the "<body>" tag.

This is very useful to add a custom HTML header, e. g. also a logo at the top of the page.

I know this would in general be possible with `WIFI_MANAGER_OVERRIDE_STRINGS` and copying the whole `wm_strings_en.h` file, however, if the only goal is to add a single line of HTML code at the top of the page this seems like a bad idea:
Whenever something would get added in that file, these changes would need to be copied over manually to the custom file again.

Having the option to just "inject" and additional HTML code at the top of the body tag (similar as it is already possible to inject something at the bottom of the "head" tag) seems a much better option.