### PR TITLE
Adde methods to se if static IP addresses were configured, and what those addresses are

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -2784,6 +2784,61 @@ void WiFiManager::setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn,
 }
 
 /**
+ * [isStaticIp description]
+ * @access public
+ * @param {[type]} void
+ * @return bool true if static network configuration was configured, false if DHCP was configured
+ * provides static or dhcp network configuration
+ */
+bool WiFiManager::isStaticIp(void) {
+    return _sta_static_ip ? true : false;
+}
+
+/**
+ * [getStaticIp description]
+ * @access public
+ * @param {[type]} IPAddress* staticIp
+ * @return void
+ * provides static host ip address provided method isStaticIp() returns true
+ */
+void WiFiManager::getStaticIp(IPAddress* staticIp) {
+    *staticIp = _sta_static_ip;
+}
+
+/**
+ * [getStaticGw description]
+ * @access public
+ * @param {[type]} IPAddress* staticGw
+ * @return void
+ * provides static gateway ip address provided method isStaticIp() returns true
+ */
+void WiFiManager::getStaticGw(IPAddress* staticGw) {
+    *staticGw = _sta_static_gw;
+}
+
+/**
+ * [getStaticSn description]
+ * @access public
+ * @param {[type]} IPAddress* staticSn
+ * @return void
+ * provides static host network mask provided method isStaticIp() returns true
+ */
+void WiFiManager::getStaticSn(IPAddress* staticSn) {
+    *staticSn = _sta_static_sn;
+}
+
+/**
+ * [getStaticDns description]
+ * @access public
+ * @param {[type]} IPAddress* staticDns
+ * @return void
+ * provides static dns address provided method isStaticIp() returns true
+ */
+void WiFiManager::getStaticDns(IPAddress* staticDns) {
+    *staticDns = _sta_static_dns;
+}
+
+/**
  * [setMinimumSignalQuality description]
  * @access public
  * @param {[type]} int quality [description]

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -358,9 +358,24 @@ class WiFiManager
     
     //sets config for a static IP
     void          setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn);
-    
+
     //sets config for a static IP with DNS
     void          setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn, IPAddress dns);
+
+    //check if static network configuration is set
+    bool          isStaticIp(void);
+
+    //provides static host ip address provided method isStaticIp() returns true
+    void          getStaticIp(IPAddress* staticIp);
+
+    //provides static gateway ip address provided method isStaticIp() returns true
+    void          getStaticGw(IPAddress* staticGw);
+
+    //provides static network mask provided method isStaticIp() returns true
+    void          getStaticSn(IPAddress* staticSn);
+
+    //provides static DNS ip address provided method isStaticIp() returns true
+    void          getStaticDns(IPAddress* staticDns);
     
     //if this is set, it will exit after config, even if connection is unsuccessful.
     void          setBreakAfterConfig(boolean shouldBreak);


### PR DESCRIPTION
To be able to find out if the network with static addresses or with DHCP following methods are proposed:

    //check if static network configuration is set
    bool          isStaticIp(void);

    //provides static host ip address provided method isStaticIp() returns true
    void          getStaticIp(IPAddress* staticIp);

    //provides static gateway ip address provided method isStaticIp() returns true
    void          getStaticGw(IPAddress* staticGw);

    //provides static network mask provided method isStaticIp() returns true
    void          getStaticSn(IPAddress* staticSn);

    //provides static DNS ip address provided method isStaticIp() returns true
    void          getStaticDns(IPAddress* staticDns);