### PR TITLE
Fix compilation warning when compiling with -Wformat flag

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3365,7 +3365,7 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
     uint32_t free = info.total_free_bytes;
     uint16_t max  = info.largest_free_block;
     uint8_t frag = 100 - (max * 100) / free;
-    _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
+    _debugPort.printf("[MEM] free: %5u | max: %5u | frag: %3u%% \n", free, max, frag);
     #endif
   }
 


### PR DESCRIPTION
Compiler warning : format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'uint32_t' 

The compiler warning arises because the format specifier %lu expects a long unsigned int, but the variable free is of type uint32_t (which is typically unsigned int). The ESP32, part of the Espressif32 family, typically defines uint32_t as unsigned int, so using the %u format specifier is appropriate.