### PR TITLE
Replace deprecated type

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -533,7 +533,7 @@ class WiFiManager
     unsigned long _startconn              = 0; // ms for timing wifi connects
 
     // defaults
-    const byte    DNS_PORT                = 53;
+    const uint8_t  DNS_PORT               = 53;
     String        _apName                 = "no-net";
     String        _apPassword             = "";
     String        _ssid                   = ""; // var temp ssid


### PR DESCRIPTION
The esp8266/Arduino v3+ now utilizes gcc10's C++17, which includes std::byte, making Arduino's byte incompatible with using namespace std, yielding the error "Reference to 'byte' is ambiguous."

to fix this I replaced `byte` with the standard type `uint8_t`





