### PR TITLE
build Failure on ESP32 Dev Module

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3366,7 +3366,9 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
     uint16_t max  = info.largest_free_block;
     uint8_t frag = 100 - (max * 100) / free;
    // _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
-    _debugPort.printf("[MEM] free: %5lu | max: %5lu | frag: %3lu%% \n", free, (unsigned long)max, (unsigned long)frag);
+  //  _debugPort.printf("[MEM] free: %5lu | max: %5lu | frag: %3lu%% \n", free, (unsigned long)max, (unsigned long)frag);
+	  _debugPort.printf("[MEM] free: %5u | max: %5u | frag: %3u%% \n", free, max, frag);
+
 
     #endif
   }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3365,7 +3365,9 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
     uint32_t free = info.total_free_bytes;
     uint16_t max  = info.largest_free_block;
     uint8_t frag = 100 - (max * 100) / free;
-    _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
+   // _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
+    _debugPort.printf("[MEM] free: %5lu | max: %5lu | frag: %3lu%% \n", free, (unsigned long)max, (unsigned long)frag);
+
     #endif
   }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -3368,6 +3368,7 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
    // _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
   //  _debugPort.printf("[MEM] free: %5lu | max: %5lu | frag: %3lu%% \n", free, (unsigned long)max, (unsigned long)frag);
 	  _debugPort.printf("[MEM] free: %5u | max: %5u | frag: %3u%% \n", free, max, frag);
+	  // _debugPort.printf("[MEM] free: %5lu | max: %5lu | frag: %3lu%% \n", free, (unsigned long)max, (unsigned long)frag);
 
 
     #endif


### PR DESCRIPTION
.pio/libdeps/esp32debug/WiFiManager/WiFiManager.cpp:150:100:   required from here
.pio/libdeps/esp32debug/WiFiManager/WiFiManager.cpp:3368:23: error: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'uint32_t' {aka 'unsigned int'} [-Werror=format=]      
     _debugPort.printf("[MEM] free: %5lu | max: %5u | frag: %3u%% \n", free, max, frag);
![Screenshot 2024-07-12 054453](https://github.com/user-attachments/assets/d63109c4-7591-4a13-a980-1c3d091ff838)

will not build when i used it for this https://github.com/zivillian/esp32-modbus-gateway.git on esp32 dev module 
