### PR TITLE
Solving problem of access violation.

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1438,9 +1438,9 @@ void WiFiManager::handleParam(){
 String WiFiManager::getMenuOut(){
   String page;  
 
-  for(auto menuId :_menuIds ){
-    if((String)_menutokens[menuId] == "param" && _paramsCount == 0) continue; // no params set, omit params from menu, @todo this may be undesired by someone, use only menu to force?
-    if((String)_menutokens[menuId] == "custom" && _customMenuHTML!=NULL){
+  for (auto menuId :_menuIds) {
+    if(strcmp_P("param", _menutokens[menuId]) == 0 && _paramsCount == 0) continue; // no params set, omit params from menu, @todo this may be undesired by someone, use only menu to force?
+    if(strcmp_P("custom", _menutokens[menuId]) == 0 && _customMenuHTML != NULL) {
       page += _customMenuHTML;
       continue;
     }


### PR DESCRIPTION

In certain scenarios, the ESP8266 was unexpectedly triggering an access violation error. After conducting a thorough debugging process, I identified and resolved the issue with this code update. The solution is based on guidance from the official ESP8266 documentation, specifically regarding the use of `PROGMEM` for handling program memory. You can find more details in the documentation here: [ESP8266 PROGMEM Documentation](https://arduino-esp8266.readthedocs.io/en/latest/PROGMEM.html#:~:text=32%20bit%20aligned.-,Functions%20to%20read%20back%20from%20PROGMEM,-%C2%B6).
