### PR TITLE
Add CSS body classes for each page

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1272,7 +1272,7 @@ void WiFiManager::startWPS() {
 }
 #endif
 
-String WiFiManager::getHTTPHead(String title){
+String WiFiManager::getHTTPHead(String title, String classes){
   String page;
   page += FPSTR(HTTP_HEAD_START);
   page.replace(FPSTR(T_v), title);
@@ -1280,14 +1280,12 @@ String WiFiManager::getHTTPHead(String title){
   page += FPSTR(HTTP_STYLE);
   page += _customHeadElement;
 
-  if(_bodyClass != ""){
-    String p = FPSTR(HTTP_HEAD_END);
-    p.replace(FPSTR(T_c), _bodyClass); // add class str
-    page += p;
+  String p = FPSTR(HTTP_HEAD_END);
+  if (_bodyClass != "") {
+      classes += " " + _bodyClass;  // add class str
   }
-  else {
-    page += FPSTR(HTTP_HEAD_END);
-  } 
+  p.replace(FPSTR(T_c), classes);
+  page += p;
 
   return page;
 }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1330,7 +1330,7 @@ void WiFiManager::handleRoot() {
   #endif
   if (captivePortal()) return; // If captive portal redirect instead of displaying the page
   handleRequest();
-  String page = getHTTPHead(_title); // @token options @todo replace options with title
+  String page = getHTTPHead(_title, FPSTR(C_root)); // @token options @todo replace options with title
   String str  = FPSTR(HTTP_ROOT_MAIN); // @todo custom title
   str.replace(FPSTR(T_t),_title);
   str.replace(FPSTR(T_v),configPortalActive ? _apName : (getWiFiHostname() + " - " + WiFi.localIP().toString())); // use ip if ap is not active for heading @todo use hostname?
@@ -1355,7 +1355,7 @@ void WiFiManager::handleWifi(boolean scan) {
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP Wifi"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titlewifi)); // @token titlewifi
+  String page = getHTTPHead(FPSTR(S_titlewifi), FPSTR(C_wifi)); // @token titlewifi
   if (scan) {
     #ifdef WM_DEBUG_LEVEL
     // DEBUG_WM(WM_DEBUG_DEV,"refresh flag:",server->hasArg(F("refresh")));
@@ -1411,7 +1411,7 @@ void WiFiManager::handleParam(){
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP Param"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titleparam)); // @token titlewifi
+  String page = getHTTPHead(FPSTR(S_titleparam), FPSTR(C_param)); // @token titlewifi
 
   String pitem = "";
 
@@ -1876,11 +1876,11 @@ void WiFiManager::handleWifiSave() {
   String page;
 
   if(_ssid == ""){
-    page = getHTTPHead(FPSTR(S_titlewifisettings)); // @token titleparamsaved
+    page = getHTTPHead(FPSTR(S_titlewifisettings), FPSTR(C_wifi)); // @token titleparamsaved
     page += FPSTR(HTTP_PARAMSAVED);
   }
   else {
-    page = getHTTPHead(FPSTR(S_titlewifisaved)); // @token titlewifisaved
+    page = getHTTPHead(FPSTR(S_titlewifisaved), FPSTR(C_wifi)); // @token titlewifisaved
     page += FPSTR(HTTP_SAVED);
   }
 
@@ -1909,7 +1909,7 @@ void WiFiManager::handleParamSave() {
 
   doParamSave();
 
-  String page = getHTTPHead(FPSTR(S_titleparamsaved)); // @token titleparamsaved
+  String page = getHTTPHead(FPSTR(S_titleparamsaved), FPSTR(C_param)); // @token titleparamsaved
   page += FPSTR(HTTP_PARAMSAVED);
   if(_showBack) page += FPSTR(HTTP_BACKBTN); 
   page += FPSTR(HTTP_END);
@@ -1975,7 +1975,7 @@ void WiFiManager::handleInfo() {
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP Info"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titleinfo)); // @token titleinfo
+  String page = getHTTPHead(FPSTR(S_titleinfo), FPSTR(C_info)); // @token titleinfo
   reportStatus(page);
 
   uint16_t infos = 0;
@@ -2320,7 +2320,7 @@ void WiFiManager::handleExit() {
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP Exit"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titleexit)); // @token titleexit
+  String page = getHTTPHead(FPSTR(S_titleexit), FPSTR(C_exit)); // @token titleexit
   page += FPSTR(S_exiting); // @token exiting
   // ('Logout', 401, {'WWW-Authenticate': 'Basic realm="Login required"'})
   server->sendHeader(F("Cache-Control"), F("no-cache, no-store, must-revalidate")); // @HTTPHEAD send cache
@@ -2337,7 +2337,7 @@ void WiFiManager::handleReset() {
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP Reset"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titlereset)); //@token titlereset
+  String page = getHTTPHead(FPSTR(S_titlereset), FPSTR(C_restart)); //@token titlereset
   page += FPSTR(S_resetting); //@token resetting
   page += FPSTR(HTTP_END);
 
@@ -2362,7 +2362,7 @@ void WiFiManager::handleErase(boolean opt) {
   DEBUG_WM(WM_DEBUG_NOTIFY,F("<- HTTP Erase"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titleerase)); // @token titleerase
+  String page = getHTTPHead(FPSTR(S_titleerase), FPSTR(C_erase)); // @token titleerase
 
   bool ret = erase(opt);
 
@@ -2467,7 +2467,7 @@ void WiFiManager::handleClose(){
   DEBUG_WM(WM_DEBUG_VERBOSE,F("<- HTTP close"));
   #endif
   handleRequest();
-  String page = getHTTPHead(FPSTR(S_titleclose)); // @token titleclose
+  String page = getHTTPHead(FPSTR(S_titleclose), FPSTR(C_close)); // @token titleclose
   page += FPSTR(S_closing); // @token closing
   HTTPSend(page);
 }
@@ -3872,7 +3872,7 @@ void WiFiManager::handleUpdate() {
 	DEBUG_WM(WM_DEBUG_VERBOSE,F("<- Handle update"));
   #endif
 	if (captivePortal()) return; // If captive portal redirect instead of displaying the page
-	String page = getHTTPHead(_title); // @token options
+	String page = getHTTPHead(_title, FPSTR(C_update)); // @token options
 	String str = FPSTR(HTTP_ROOT_MAIN);
   str.replace(FPSTR(T_t), _title);
 	str.replace(FPSTR(T_v), configPortalActive ? _apName : (getWiFiHostname() + " - " + WiFi.localIP().toString())); // use ip if ap is not active for heading
@@ -3982,7 +3982,7 @@ void WiFiManager::handleUpdateDone() {
 	DEBUG_WM(WM_DEBUG_VERBOSE, F("<- Handle update done"));
 	// if (captivePortal()) return; // If captive portal redirect instead of displaying the page
 
-	String page = getHTTPHead(FPSTR(S_options)); // @token options
+	String page = getHTTPHead(FPSTR(S_options), FPSTR(C_update)); // @token options
 	String str  = FPSTR(HTTP_ROOT_MAIN);
   str.replace(FPSTR(T_t),_title);
 	str.replace(FPSTR(T_v), configPortalActive ? _apName : WiFi.localIP().toString()); // use ip if ap is not active for heading

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1282,7 +1282,10 @@ String WiFiManager::getHTTPHead(String title, String classes){
 
   String p = FPSTR(HTTP_HEAD_END);
   if (_bodyClass != "") {
-      classes += " " + _bodyClass;  // add class str
+    if (classes != "") {
+      classes += " ";  // add spacing, if necessary
+    }
+    classes += _bodyClass;  // add class str
   }
   p.replace(FPSTR(T_c), classes);
   page += p;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -751,7 +751,7 @@ protected:
     String        getIpForm(String id, String title, String value);
     String        getScanItemOut();
     String        getStaticOut();
-    String        getHTTPHead(String title);
+    String        getHTTPHead(String title, String classes = "");
     String        getMenuOut();
     //helpers
     boolean       isIp(String str);

--- a/wm_consts_en.h
+++ b/wm_consts_en.h
@@ -64,7 +64,7 @@ const char R_updatedone[]         PROGMEM = "/u";
 
 
 // Classes
-const char C_root[]               PROGMEM = "root";
+const char C_root[]               PROGMEM = "home";
 const char C_wifi[]               PROGMEM = "wifi";
 const char C_info[]               PROGMEM = "info";
 const char C_param[]              PROGMEM = "param";

--- a/wm_consts_en.h
+++ b/wm_consts_en.h
@@ -46,6 +46,7 @@ static PGM_P _menutokens[] PROGMEM = {
 const uint8_t _nummenutokens = (sizeof(_menutokens) / sizeof(PGM_P));
 
 
+// Routes
 const char R_root[]               PROGMEM = "/";
 const char R_wifi[]               PROGMEM = "/wifi";
 const char R_wifinoscan[]         PROGMEM = "/0wifi";
@@ -60,6 +61,18 @@ const char R_erase[]              PROGMEM = "/erase";
 const char R_status[]             PROGMEM = "/status";
 const char R_update[]             PROGMEM = "/update";
 const char R_updatedone[]         PROGMEM = "/u";
+
+
+// Classes
+const char C_root[]               PROGMEM = "root";
+const char C_wifi[]               PROGMEM = "wifi";
+const char C_info[]               PROGMEM = "info";
+const char C_param[]              PROGMEM = "param";
+const char C_close[]              PROGMEM = "close";
+const char C_restart[]            PROGMEM = "restart";
+const char C_exit[]               PROGMEM = "exit";
+const char C_erase[]              PROGMEM = "erase";
+const char C_update[]             PROGMEM = "update";
 
 
 //Strings

--- a/wm_consts_fr.h
+++ b/wm_consts_fr.h
@@ -65,7 +65,7 @@ const char R_updatedone[]         PROGMEM = "/u";
 
 
 // Classes
-const char C_root[]               PROGMEM = "root";
+const char C_root[]               PROGMEM = "home";
 const char C_wifi[]               PROGMEM = "wifi";
 const char C_info[]               PROGMEM = "info";
 const char C_param[]              PROGMEM = "param";

--- a/wm_consts_fr.h
+++ b/wm_consts_fr.h
@@ -47,6 +47,7 @@ static PGM_P _menutokens[] PROGMEM = {
 const uint8_t _nummenutokens = (sizeof(_menutokens) / sizeof(PGM_P));
 
 
+// Routes
 const char R_root[]               PROGMEM = "/";
 const char R_wifi[]               PROGMEM = "/wifi";
 const char R_wifinoscan[]         PROGMEM = "/0wifi";
@@ -61,6 +62,18 @@ const char R_erase[]              PROGMEM = "/erase";
 const char R_status[]             PROGMEM = "/status";
 const char R_update[]             PROGMEM = "/update";
 const char R_updatedone[]         PROGMEM = "/u";
+
+
+// Classes
+const char C_root[]               PROGMEM = "root";
+const char C_wifi[]               PROGMEM = "wifi";
+const char C_info[]               PROGMEM = "info";
+const char C_param[]              PROGMEM = "param";
+const char C_close[]              PROGMEM = "close";
+const char C_restart[]            PROGMEM = "restart";
+const char C_exit[]               PROGMEM = "exit";
+const char C_erase[]              PROGMEM = "erase";
+const char C_update[]             PROGMEM = "update";
 
 
 //Strings


### PR DESCRIPTION
This PR adds classes to the body element for each individual page, so that it's easier to style pages differently:

| Title (en)        | Route      | Class   |
|-------------------|------------|---------|
| WiFiManager       | /          | home    |
| Config ESP        | /wifi      | wifi    |
| Credentials saved | /wifisave  | wifi    |
| Info              | /info      | info    |
| Setup             | /param     | param   |
| Setup saved       | /paramsave | param   |
| Restart           | /restart   | restart |
| Exit              | /exit      | exit    |
| Close             | /close     | close   |
| Erase             | /erase     | erase   |
| Update            | /update    | update  |
| options           | /u         | update  |

This is accomplished by modifying the `getHTTPHead()` function to add an optional `String` argument for classes to add, and a set of constant class strings in the `wm_consts` header. The class strings are then invoked in each respective route "handle" function when the head is generated.

I did not add separate classes for the "saved" pages, as that seemed excessive. But I'm happy to go in and add them if you think it would be beneficial.

This change does not break the current API and should add minimal overhead.