### PR TITLE
WiFiManagerParameter max length and encapsulation

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -86,6 +86,11 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int maxLength) {
     // Serial.println("cannot set value of this parameter");
     return;
   }
+
+  if(maxLength < 0){
+      // Serial.println("cannot set length below zero");
+      return;
+  }
   
   // if(strlen(defaultValue) > maxLength){
   //   // Serial.println("defaultValue length mismatch");

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -76,6 +76,10 @@ WiFiManagerParameter::~WiFiManagerParameter() {
 //   return *this;
 // }
 
+void WiFiManagerParameter::setValue(const char *defaultValue) {
+    setValue(defaultValue, getValueLength());  // use the existing max length
+}
+
 // @note debug is not available in wmparameter class
 void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
   if(!_id){

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1739,8 +1739,8 @@ String WiFiManager::getParamOut(){
     char valLength[5];
 
     for (int i = 0; i < _paramsCount; i++) {
-      //Serial.println((String)_params[i]->_length);
-      if (_params[i] == NULL || _params[i]->_length > 99999) {
+      //Serial.println((String)_params[i]->getValueLength());
+      if (_params[i] == NULL || _params[i]->getValueLength() > 99999) {
         // try to detect param scope issues, doesnt always catch but works ok
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
@@ -1941,7 +1941,7 @@ void WiFiManager::doParamSave(){
     #endif
 
     for (int i = 0; i < _paramsCount; i++) {
-      if (_params[i] == NULL || _params[i]->_length > 99999) {
+      if (_params[i] == NULL || _params[i]->getValueLength() > 99999) {
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
         #endif
@@ -1957,7 +1957,7 @@ void WiFiManager::doParamSave(){
       }
 
       //store it in params array
-      value.toCharArray(_params[i]->_value, _params[i]->_length+1); // length+1 null terminated
+      _params[i]->setValue(value.c_str());
       #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(WM_DEBUG_VERBOSE,(String)_params[i]->getID() + ":",value);
       #endif

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -41,26 +41,26 @@ WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label) {
   init(id, label, "", 0, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length) {
-  init(id, label, defaultValue, length, "", WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength) {
+  init(id, label, defaultValue, maxLength, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom) {
-  init(id, label, defaultValue, length, custom, WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom) {
+  init(id, label, defaultValue, maxLength, custom, WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement) {
-  init(id, label, defaultValue, length, custom, labelPlacement);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
+  init(id, label, defaultValue, maxLength, custom, labelPlacement);
 }
 
-void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement) {
+void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
   _id             = id;
   _label          = label;
   _labelPlacement = labelPlacement;
   _customHTML     = custom;
   _length         = 0;
   _value          = nullptr;
-  setValue(defaultValue,length);
+  setValue(defaultValue, maxLength);
 }
 
 WiFiManagerParameter::~WiFiManagerParameter() {
@@ -81,19 +81,19 @@ void WiFiManagerParameter::setValue(const char *defaultValue) {
 }
 
 // @note debug is not available in wmparameter class
-void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
+void WiFiManagerParameter::setValue(const char *defaultValue, int maxLength) {
   if(!_id){
     // Serial.println("cannot set value of this parameter");
     return;
   }
   
-  // if(strlen(defaultValue) > length){
+  // if(strlen(defaultValue) > maxLength){
   //   // Serial.println("defaultValue length mismatch");
   //   // return false; //@todo bail 
   // }
 
-  if(_length != length || _value == nullptr){
-    _length = length;
+  if(_length != maxLength || _value == nullptr){
+    _length = maxLength;
     if( _value != nullptr){
       delete[] _value;
     }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -77,7 +77,7 @@ WiFiManagerParameter::~WiFiManagerParameter() {
 // }
 
 void WiFiManagerParameter::setValue(const char *defaultValue) {
-    setValue(defaultValue, getValueLength());  // use the existing max length
+    setValue(defaultValue, getValueMaxLength());  // use the existing max length
 }
 
 // @note debug is not available in wmparameter class
@@ -121,6 +121,9 @@ const char* WiFiManagerParameter::getLabel() const {
 }
 int WiFiManagerParameter::getValueLength() const {
   return _length;
+}
+int WiFiManagerParameter::getValueMaxLength() const {
+    return _length;
 }
 int WiFiManagerParameter::getLabelPlacement() const {
   return _labelPlacement;
@@ -1739,8 +1742,8 @@ String WiFiManager::getParamOut(){
     char valLength[5];
 
     for (int i = 0; i < _paramsCount; i++) {
-      //Serial.println((String)_params[i]->getValueLength());
-      if (_params[i] == NULL || _params[i]->getValueLength() > 99999) {
+      //Serial.println((String)_params[i]->getValueMaxLength());
+      if (_params[i] == NULL || _params[i]->getValueMaxLength() > 99999) {
         // try to detect param scope issues, doesnt always catch but works ok
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
@@ -1777,7 +1780,7 @@ String WiFiManager::getParamOut(){
         if(tok_n)pitem.replace(FPSTR(T_n), _params[i]->getID()); // T_n id name alias
         if(tok_p)pitem.replace(FPSTR(T_p), FPSTR(T_t)); // T_p replace legacy placeholder token
         if(tok_t)pitem.replace(FPSTR(T_t), _params[i]->getLabel()); // T_t title/label
-        snprintf(valLength, 5, "%d", _params[i]->getValueLength());
+        snprintf(valLength, 5, "%d", _params[i]->getValueMaxLength());
         if(tok_l)pitem.replace(FPSTR(T_l), valLength); // T_l value length
         if(tok_v)pitem.replace(FPSTR(T_v), _params[i]->getValue()); // T_v value
         if(tok_c)pitem.replace(FPSTR(T_c), _params[i]->getCustomHTML()); // T_c meant for additional attributes, not html, but can stuff
@@ -1941,7 +1944,7 @@ void WiFiManager::doParamSave(){
     #endif
 
     for (int i = 0; i < _paramsCount; i++) {
-      if (_params[i] == NULL || _params[i]->getValueLength() > 99999) {
+      if (_params[i] == NULL || _params[i]->getValueMaxLength() > 99999) {
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
         #endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -232,7 +232,6 @@ class WiFiManagerParameter {
     int         _labelPlacement;
   
     const char *_customHTML;
-    friend class WiFiManager; // @deprecated
 };
 
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -214,7 +214,8 @@ class WiFiManagerParameter {
     const char *getValue() const;
     const char *getLabel() const;
     const char *getPlaceholder() const; // @deprecated, use getLabel
-    int         getValueLength() const;
+    int         getValueLength() const; // @deprecated, use getValueMaxLength
+    int         getValueMaxLength() const;
     int         getLabelPlacement() const;
     virtual const char *getCustomHTML() const;
     void        setValue(const char *defaultValue);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -231,7 +231,7 @@ class WiFiManagerParameter {
     int         _labelPlacement;
   
     const char *_customHTML;
-    friend class WiFiManager;
+    friend class WiFiManager; // @deprecated
 };
 
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -217,6 +217,7 @@ class WiFiManagerParameter {
     int         getValueLength() const;
     int         getLabelPlacement() const;
     virtual const char *getCustomHTML() const;
+    void        setValue(const char *defaultValue);
     void        setValue(const char *defaultValue, int length);
 
   protected:

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -204,9 +204,9 @@ class WiFiManagerParameter {
     WiFiManagerParameter();
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *label);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
     ~WiFiManagerParameter();
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
@@ -218,16 +218,16 @@ class WiFiManagerParameter {
     int         getLabelPlacement() const;
     virtual const char *getCustomHTML() const;
     void        setValue(const char *defaultValue);
-    void        setValue(const char *defaultValue, int length);
+    void        setValue(const char *defaultValue, int maxLength);
 
   protected:
-    void init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
+    void init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
 
     WiFiManagerParameter& operator=(const WiFiManagerParameter&);
     const char *_id;
     const char *_label;
     char       *_value;
-    int         _length;
+    int         _length; // @deprecated this should be _maxLength
     int         _labelPlacement;
   
     const char *_customHTML;

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,7 +30,7 @@ addParameter KEYWORD2
 getID KEYWORD2
 getValue KEYWORD2
 getPlaceholder KEYWORD2
-getValueLength KEYWORD2
+getValueMaxLength KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
This PR performs a few fixes around the `WiFiManagerParameter` class to improve clarity, usability, and encapsulation:

* The `length` parameter has been changed to `maxLength` for all class functions
    * The parameter refers to the max length of the form and the size of the internal buffer, not the length of the string passed as an argument. The internal name (`_length`) has *not* been changed to maintain compatibility with user code, as it's exposed as a protected value and through friendship with `WiFiManager`.
* `setValue()` now has a version without a max length argument
    * The original 'length' argument was confusing as a user, since it seemed to refer to the length of the string passed in while it's actually the max length of the buffer / value in the form. This new function allows for changing the value without changing the max length.
* `getValueLength()` has been changed to `getValueMaxLength()`
    * This better represents what is being returned, since it's the maximum length of the form / buffer and not the length of the value (i.e. what's *currently* in the buffer, and what's returned from the webpage). The original function is marked deprecated and has not been changed for compatibility reasons, but it would be nice if it returned the length of the value in the next major release.
* Friendship between  `WiFiManagerParameter` and `WiFiManager` has been removed
    * The few internal calls in `WiFiManager` have been changed to use the public functions and there is no remaining reason for the friendship to exist. Removing the friendship boosts encapsulation.
* `setValue()` now checks for a negative max length
    * All of the corresponding 'length' arguments should probably be unsigned (`size_t`). Again, this was not changed so-as not to break backwards-compatibility.

This PR should have **no** breaking changes. The few items marked deprecated should be removed on the next major release.

---

If this is merged, here are the changes to make on the next major release:
* `WiFiManagerParameter::_length` should be refactored to `_maxLength`
* `WiFiManagerParameter::getValueLength() const` should be removed
* All `WiFiManagerParameter` `maxLength` arguments should use `size_t` instead of `int`
