### PR TITLE
WiFiManagerParameter Checkboxes and Radios

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1748,8 +1748,8 @@ String WiFiManager::getParamOut(){
     char valLength[5];
 
     for (int i = 0; i < _paramsCount; i++) {
-      //Serial.println((String)_params[i]->_length);
-      if (_params[i] == NULL || _params[i]->_length > 99999) {
+      //Serial.println((String)_params[i]->getValueMaxLength());
+      if (_params[i] == NULL || _params[i]->getValueMaxLength() > 99999) {
         // try to detect param scope issues, doesnt always catch but works ok
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
@@ -1950,7 +1950,7 @@ void WiFiManager::doParamSave(){
     #endif
 
     for (int i = 0; i < _paramsCount; i++) {
-      if (_params[i] == NULL || _params[i]->_length > 99999) {
+      if (_params[i] == NULL || _params[i]->getValueMaxLength() > 99999) {
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] WiFiManagerParameter is out of scope"));
         #endif

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1809,10 +1809,6 @@ String WiFiManager::getParamOut(){
 
   if(_paramsCount > 0){
 
-    String HTTP_PARAM_temp = FPSTR(HTTP_FORM_LABEL);
-    HTTP_PARAM_temp += FPSTR(HTTP_FORM_PARAM);
-    bool tok_I = HTTP_PARAM_temp.indexOf(FPSTR(T_I)) > 0;
-
     for (int i = 0; i < _paramsCount; i++) {
       //Serial.println((String)_params[i]->getValueMaxLength());
       if (_params[i] == NULL || _params[i]->getValueMaxLength() > 99999) {
@@ -1826,17 +1822,7 @@ String WiFiManager::getParamOut(){
 
     // add the extra parameters to the form
     for (int i = 0; i < _paramsCount; i++) {
-      String pitem;
-
-      if(_params[i]->getName() != NULL) {
-        pitem = _params[i]->getHTML();
-        if (tok_I) pitem.replace(FPSTR(T_I), (String)FPSTR(S_parampre) + (String)i); // T_I id number
-      }
-      else {
-        pitem = _params[i]->getHTML();
-      }
-
-      page += pitem;
+      page += _params[i]->getHTML();
     }
   }
 

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -37,24 +37,24 @@ WiFiManagerParameter::WiFiManagerParameter(const char *custom) {
   _customHTML     = custom;
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label) {
-  init(id, label, "", 0, "", WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *name, const char *label) {
+  init(name, label, "", 0, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength) {
-  init(id, label, defaultValue, maxLength, "", WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength) {
+  init(name, label, defaultValue, maxLength, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom) {
-  init(id, label, defaultValue, maxLength, custom, WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom) {
+  init(name, label, defaultValue, maxLength, custom, WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
-  init(id, label, defaultValue, maxLength, custom, labelPlacement);
+WiFiManagerParameter::WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
+  init(name, label, defaultValue, maxLength, custom, labelPlacement);
 }
 
-void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
-  _id             = id;
+void WiFiManagerParameter::init(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
+  _id             = name;
   _label          = label;
   _labelPlacement = labelPlacement;
   _customHTML     = custom;
@@ -106,6 +106,9 @@ const char* WiFiManagerParameter::getValue() const {
   // Serial.println(printf("Address of _value is %p\n", (void *)_value)); 
   return _value;
 }
+const char* WiFiManagerParameter::getName() const {
+    return _id;
+}
 const char* WiFiManagerParameter::getID() const {
   return _id;
 }
@@ -135,12 +138,12 @@ const char* WiFiManagerParameter::getCustomHTML() const {
  */
 bool WiFiManager::addParameter(WiFiManagerParameter *p) {
 
-  // check param id is valid, unless null
-  if(p->getID()){
-    for (size_t i = 0; i < strlen(p->getID()); i++){
-       if(!(isAlphaNumeric(p->getID()[i])) && !(p->getID()[i]=='_')){
+  // check param name is valid, unless null
+  if(p->getName()){
+    for (size_t i = 0; i < strlen(p->getName()); i++){
+       if(!(isAlphaNumeric(p->getName()[i])) && !(p->getName()[i]=='_')){
         #ifdef WM_DEBUG_LEVEL
-        DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] parameter IDs can only contain alpha numeric chars"));
+        DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] parameter names can only contain alpha numeric chars"));
         #endif
         return false;
        }
@@ -182,7 +185,7 @@ bool WiFiManager::addParameter(WiFiManagerParameter *p) {
   _paramsCount++;
   
   #ifdef WM_DEBUG_LEVEL
-  DEBUG_WM(WM_DEBUG_VERBOSE,F("Added Parameter:"),p->getID());
+  DEBUG_WM(WM_DEBUG_VERBOSE,F("Added Parameter:"),p->getName());
   #endif
   return true;
 }
@@ -1770,10 +1773,10 @@ String WiFiManager::getParamOut(){
       // Input templating
       // "<br/><input id='{i}' name='{n}' maxlength='{l}' value='{v}' {c}>";
       // if no ID use customhtml for item, else generate from param string
-      if (_params[i]->getID() != NULL) {
+      if (_params[i]->getName() != NULL) {
         if(tok_I)pitem.replace(FPSTR(T_I), (String)FPSTR(S_parampre)+(String)i); // T_I id number
-        if(tok_i)pitem.replace(FPSTR(T_i), _params[i]->getID()); // T_i id name
-        if(tok_n)pitem.replace(FPSTR(T_n), _params[i]->getID()); // T_n id name alias
+        if(tok_i)pitem.replace(FPSTR(T_i), _params[i]->getName()); // T_i name
+        if(tok_n)pitem.replace(FPSTR(T_n), _params[i]->getName()); // T_n name alias
         if(tok_p)pitem.replace(FPSTR(T_p), FPSTR(T_t)); // T_p replace legacy placeholder token
         if(tok_t)pitem.replace(FPSTR(T_t), _params[i]->getLabel()); // T_t title/label
         snprintf(valLength, 5, "%d", _params[i]->getValueMaxLength());
@@ -1952,13 +1955,13 @@ void WiFiManager::doParamSave(){
       if(server->hasArg(name)) {
         value = server->arg(name);
       } else {
-        value = server->arg(_params[i]->getID());
+        value = server->arg(_params[i]->getName());
       }
 
       //store it in params array
       value.toCharArray(_params[i]->_value, _params[i]->_length+1); // length+1 null terminated
       #ifdef WM_DEBUG_LEVEL
-      DEBUG_WM(WM_DEBUG_VERBOSE,(String)_params[i]->getID() + ":",value);
+      DEBUG_WM(WM_DEBUG_VERBOSE,(String)_params[i]->getName() + ":",value);
       #endif
     }
     #ifdef WM_DEBUG_LEVEL

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -41,26 +41,26 @@ WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label) {
   init(id, label, "", 0, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length) {
-  init(id, label, defaultValue, length, "", WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength) {
+  init(id, label, defaultValue, maxLength, "", WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom) {
-  init(id, label, defaultValue, length, custom, WFM_LABEL_DEFAULT);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom) {
+  init(id, label, defaultValue, maxLength, custom, WFM_LABEL_DEFAULT);
 }
 
-WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement) {
-  init(id, label, defaultValue, length, custom, labelPlacement);
+WiFiManagerParameter::WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
+  init(id, label, defaultValue, maxLength, custom, labelPlacement);
 }
 
-void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement) {
+void WiFiManagerParameter::init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement) {
   _id             = id;
   _label          = label;
   _labelPlacement = labelPlacement;
   _customHTML     = custom;
   _length         = 0;
   _value          = nullptr;
-  setValue(defaultValue,length);
+  setValue(defaultValue, maxLength);
 }
 
 WiFiManagerParameter::~WiFiManagerParameter() {
@@ -77,19 +77,19 @@ WiFiManagerParameter::~WiFiManagerParameter() {
 // }
 
 // @note debug is not available in wmparameter class
-void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
+void WiFiManagerParameter::setValue(const char *defaultValue, int maxLength) {
   if(!_id){
     // Serial.println("cannot set value of this parameter");
     return;
   }
   
-  // if(strlen(defaultValue) > length){
+  // if(strlen(defaultValue) > maxLength){
   //   // Serial.println("defaultValue length mismatch");
   //   // return false; //@todo bail 
   // }
 
-  if(_length != length || _value == nullptr){
-    _length = length;
+  if(_length != maxLength || _value == nullptr){
+    _length = maxLength;
     if( _value != nullptr){
       delete[] _value;
     }

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -82,6 +82,11 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int maxLength) {
     // Serial.println("cannot set value of this parameter");
     return;
   }
+
+  if(maxLength < 0){
+      // Serial.println("cannot set length below zero");
+      return;
+  }
   
   // if(strlen(defaultValue) > maxLength){
   //   // Serial.println("defaultValue length mismatch");

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -118,6 +118,9 @@ const char* WiFiManagerParameter::getLabel() const {
 int WiFiManagerParameter::getValueLength() const {
   return _length;
 }
+int WiFiManagerParameter::getValueMaxLength() const {
+    return _length;
+}
 int WiFiManagerParameter::getLabelPlacement() const {
   return _labelPlacement;
 }
@@ -1773,7 +1776,7 @@ String WiFiManager::getParamOut(){
         if(tok_n)pitem.replace(FPSTR(T_n), _params[i]->getID()); // T_n id name alias
         if(tok_p)pitem.replace(FPSTR(T_p), FPSTR(T_t)); // T_p replace legacy placeholder token
         if(tok_t)pitem.replace(FPSTR(T_t), _params[i]->getLabel()); // T_t title/label
-        snprintf(valLength, 5, "%d", _params[i]->getValueLength());
+        snprintf(valLength, 5, "%d", _params[i]->getValueMaxLength());
         if(tok_l)pitem.replace(FPSTR(T_l), valLength); // T_l value length
         if(tok_v)pitem.replace(FPSTR(T_v), _params[i]->getValue()); // T_v value
         if(tok_c)pitem.replace(FPSTR(T_c), _params[i]->getCustomHTML()); // T_c meant for additional attributes, not html, but can stuff

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -102,6 +102,13 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int maxLength) {
     strncpy(_value, defaultValue, _length);
   }
 }
+
+void WiFiManagerParameter::setValueReceived(const char* value) {
+    // by default, this just passes through to 'setValue'
+    // derived classes can intercept the received value here
+    setValue(value, getValueMaxLength());
+}
+
 const char* WiFiManagerParameter::getValue() const {
   // Serial.println(printf("Address of _value is %p\n", (void *)_value)); 
   return _value;
@@ -1959,7 +1966,7 @@ void WiFiManager::doParamSave(){
       }
 
       //store it in params array
-      value.toCharArray(_params[i]->_value, _params[i]->_length+1); // length+1 null terminated
+      _params[i]->setValueReceived(value.c_str());
       #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(WM_DEBUG_VERBOSE,(String)_params[i]->getName() + ":",value);
       #endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -237,6 +237,26 @@ class WiFiManagerParameter {
     const char *_customHTML;
 };
 
+class WiFiManagerParameterCheckbox : public WiFiManagerParameter {
+public:
+    WiFiManagerParameterCheckbox(
+        const char* name,
+        const char* label,
+        const char* value,
+        bool        checked = false,
+        const char* custom = "",
+        int         labelPlacement = WFM_LABEL_AFTER);
+
+    virtual String getHTML() const;
+    virtual void   setValueReceived(const char* value);
+
+    bool getChecked() const;
+    void setChecked(bool checked);
+
+private:
+    bool _checked;
+};
+
 
     // debugging
     typedef enum {

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -203,14 +203,15 @@ class WiFiManagerParameter {
     */
     WiFiManagerParameter();
     WiFiManagerParameter(const char *custom);
-    WiFiManagerParameter(const char *id, const char *label);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
+    WiFiManagerParameter(const char *name, const char *label);
+    WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength);
+    WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom);
+    WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
     ~WiFiManagerParameter();
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
-    const char *getID() const;
+    const char *getName() const;
+    const char *getID() const;          // @deprecated, use getName
     const char *getValue() const;
     const char *getLabel() const;
     const char *getPlaceholder() const; // @deprecated, use getLabel
@@ -221,10 +222,10 @@ class WiFiManagerParameter {
     void        setValue(const char *defaultValue, int maxLength);
 
   protected:
-    void init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
+    void init(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
 
     WiFiManagerParameter& operator=(const WiFiManagerParameter&);
-    const char *_id;
+    const char *_id;    // @deprecated this should be _name
     const char *_label;
     char       *_value;
     int         _length; // @deprecated this should be _maxLength

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -207,7 +207,7 @@ class WiFiManagerParameter {
     WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength);
     WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom);
     WiFiManagerParameter(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
-    ~WiFiManagerParameter();
+    virtual ~WiFiManagerParameter();
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
     const char *getName() const;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -204,9 +204,9 @@ class WiFiManagerParameter {
     WiFiManagerParameter();
     WiFiManagerParameter(const char *custom);
     WiFiManagerParameter(const char *id, const char *label);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom);
-    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom);
+    WiFiManagerParameter(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
     ~WiFiManagerParameter();
     // WiFiManagerParameter& operator=(const WiFiManagerParameter& rhs);
 
@@ -217,16 +217,16 @@ class WiFiManagerParameter {
     int         getValueLength() const;
     int         getLabelPlacement() const;
     virtual const char *getCustomHTML() const;
-    void        setValue(const char *defaultValue, int length);
+    void        setValue(const char *defaultValue, int maxLength);
 
   protected:
-    void init(const char *id, const char *label, const char *defaultValue, int length, const char *custom, int labelPlacement);
+    void init(const char *id, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
 
     WiFiManagerParameter& operator=(const WiFiManagerParameter&);
     const char *_id;
     const char *_label;
     char       *_value;
-    int         _length;
+    int         _length; // @deprecated this should be _maxLength
     int         _labelPlacement;
   
     const char *_customHTML;

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -234,7 +234,6 @@ class WiFiManagerParameter {
     int         _labelPlacement;
   
     const char *_customHTML;
-    friend class WiFiManager;
 };
 
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -214,7 +214,8 @@ class WiFiManagerParameter {
     const char *getValue() const;
     const char *getLabel() const;
     const char *getPlaceholder() const; // @deprecated, use getLabel
-    int         getValueLength() const;
+    int         getValueLength() const; // @deprecated, use getValueMaxLength
+    int         getValueMaxLength() const;
     int         getLabelPlacement() const;
     virtual const char *getCustomHTML() const;
     void        setValue(const char *defaultValue, int maxLength);

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -221,6 +221,8 @@ class WiFiManagerParameter {
     virtual const char *getCustomHTML() const;
     void        setValue(const char *defaultValue, int maxLength);
 
+    virtual void   setValueReceived(const char* value);
+
   protected:
     void init(const char *name, const char *label, const char *defaultValue, int maxLength, const char *custom, int labelPlacement);
 

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -257,6 +257,33 @@ private:
     bool _checked;
 };
 
+class WiFiManagerParameterRadio : public WiFiManagerParameter {
+public:
+    WiFiManagerParameterRadio(
+        const char* name,
+        const char* custom = "",
+        int         labelPlacement = WFM_LABEL_AFTER);
+
+    void addOption(const char* id, const char* label, const char* value, bool selected);
+    void clear();
+
+    virtual String getHTML() const;
+    virtual void   setValueReceived(const char* value);
+
+private:
+    struct RadioOption {
+        const char* id;
+        const char* label;
+        const char* value;
+    };
+
+    bool   valueSelected(const char* value) const;
+    String generateOptionHTML(const RadioOption& option) const;
+
+    std::vector<RadioOption> options;
+    size_t maxBufferSize;
+};
+
 
     // debugging
     typedef enum {

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -221,6 +221,7 @@ class WiFiManagerParameter {
     virtual const char *getCustomHTML() const;
     void        setValue(const char *defaultValue, int maxLength);
 
+    virtual String getHTML() const;
     virtual void   setValueReceived(const char* value);
 
   protected:

--- a/examples/NonBlocking/AutoConnectNonBlockingwParams/AutoConnectNonBlockingwParams.ino
+++ b/examples/NonBlocking/AutoConnectNonBlockingwParams/AutoConnectNonBlockingwParams.ino
@@ -30,7 +30,7 @@ void loop() {
 
 void saveParamsCallback () {
   Serial.println("Get Params:");
-  Serial.print(custom_mqtt_server.getID());
+  Serial.print(custom_mqtt_server.getName());
   Serial.print(" : ");
   Serial.println(custom_mqtt_server.getValue());
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,7 +30,7 @@ addParameter KEYWORD2
 getID KEYWORD2
 getValue KEYWORD2
 getPlaceholder KEYWORD2
-getValueLength KEYWORD2
+getValueMaxLength KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ setSTAStaticIPConfig KEYWORD2
 setAPCallback	KEYWORD2
 setSaveConfigCallback KEYWORD2
 addParameter KEYWORD2
-getID KEYWORD2
+getName	KEYWORD2
 getValue KEYWORD2
 getPlaceholder KEYWORD2
 getValueMaxLength KEYWORD2

--- a/wm_consts_en.h
+++ b/wm_consts_en.h
@@ -84,6 +84,7 @@ const char T_i[]                  PROGMEM = "{i}"; // @token i
 const char T_n[]                  PROGMEM = "{n}"; // @token n
 const char T_p[]                  PROGMEM = "{p}"; // @token p
 const char T_t[]                  PROGMEM = "{t}"; // @token t
+const char T_T[]                  PROGMEM = "{T}"; // @token T
 const char T_l[]                  PROGMEM = "{l}"; // @token l
 const char T_c[]                  PROGMEM = "{c}"; // @token c
 const char T_e[]                  PROGMEM = "{e}"; // @token e

--- a/wm_consts_fr.h
+++ b/wm_consts_fr.h
@@ -85,6 +85,7 @@ const char T_i[]                  PROGMEM = "{i}"; // @token i
 const char T_n[]                  PROGMEM = "{n}"; // @token n
 const char T_p[]                  PROGMEM = "{p}"; // @token p
 const char T_t[]                  PROGMEM = "{t}"; // @token t
+const char T_T[]                  PROGMEM = "{T}"; // @token T
 const char T_l[]                  PROGMEM = "{l}"; // @token l
 const char T_c[]                  PROGMEM = "{c}"; // @token c
 const char T_e[]                  PROGMEM = "{e}"; // @token e

--- a/wm_strings_en.h
+++ b/wm_strings_en.h
@@ -70,6 +70,7 @@ const char HTTP_FORM_END[]         PROGMEM = "<br/><br/><button type='submit'>Sa
 const char HTTP_FORM_LABEL[]       PROGMEM = "<label for='{i}'>{t}</label>";
 const char HTTP_FORM_PARAM_HEAD[]  PROGMEM = "<hr><br/>";
 const char HTTP_FORM_PARAM[]       PROGMEM = "<br/><input id='{i}' name='{n}' maxlength='{l}' value='{v}' {c}>\n"; // do not remove newline!
+const char HTTP_FORM_PARAM_CHECK[] PROGMEM = "<input type='{T}' name='{n}' id='{i}' value='{v}' {c}>\n";
 
 const char HTTP_SCAN_LINK[]        PROGMEM = "<br/><form action='/wifi?refresh=1' method='POST'><button name='refresh' value='1'>Refresh</button></form>";
 const char HTTP_SAVED[]            PROGMEM = "<div class='msg'>Saving Credentials<br/>Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";

--- a/wm_strings_es.h
+++ b/wm_strings_es.h
@@ -78,6 +78,7 @@ const char HTTP_FORM_END[]         PROGMEM = "<br/><br/><button type='submit'>Sa
 const char HTTP_FORM_LABEL[]       PROGMEM = "<label for='{i}'>{t}</label>";
 const char HTTP_FORM_PARAM_HEAD[]  PROGMEM = "<hr><br/>";
 const char HTTP_FORM_PARAM[]       PROGMEM = "<br/><input id='{i}' name='{n}' maxlength='{l}' value='{v}' {c}>\n"; // do not remove newline!
+const char HTTP_FORM_PARAM_CHECK[] PROGMEM = "<input type='{T}' name='{n}' id='{i}' value='{v}' {c}>\n";
 
 const char HTTP_SCAN_LINK[]        PROGMEM = "<br/><form action='/wifi?refresh=1' method='POST'><button name='refresh' value='1'>Refresh</button></form>";
 const char HTTP_SAVED[]            PROGMEM = "<div class='msg'>Saving Credentials<br/>Trying to connect ESP to network.<br />If it fails reconnect to AP to try again</div>";

--- a/wm_strings_fr.h
+++ b/wm_strings_fr.h
@@ -71,6 +71,7 @@ const char HTTP_FORM_END[]         PROGMEM = "<br/><br/><button type='submit'>En
 const char HTTP_FORM_LABEL[]       PROGMEM = "<label for='{i}'>{t}</label>";
 const char HTTP_FORM_PARAM_HEAD[]  PROGMEM = "<hr><br/>";
 const char HTTP_FORM_PARAM[]       PROGMEM = "<br/><input id='{i}' name='{n}' maxlength='{l}' value='{v}' {c}>\n"; // do not remove newline!
+const char HTTP_FORM_PARAM_CHECK[] PROGMEM = "<input type='{T}' name='{n}' id='{i}' value='{v}' {c}>\n";
 
 const char HTTP_SCAN_LINK[]        PROGMEM = "<br/><form action='/wifi?refresh=1' method='POST'><button name='refresh' value='1'>Rafraichir</button></form>";
 const char HTTP_SAVED[]            PROGMEM = "<div class='msg'>Enregistrer l'accès<br/>L'ESP essai de se connecter au réseau.<br />Si échec, merci de vous reconnecter à nouveau.</div>";


### PR DESCRIPTION
This PR adds checkbox and radio input classes derived from `WiFiManagerParameter`, allowing users to easily add those inputs to their config pages.

# Checkboxes


## Demo
### User Code
```cpp
WiFiManagerParameterCheckbox checkboxes[] = {
	WiFiManagerParameterCheckbox("checkbox1", "Checkbox 1", "chk1", true),
	WiFiManagerParameterCheckbox("checkbox2", "Checkbox 2", "chk2", false),
	WiFiManagerParameterCheckbox("checkbox3", "Checkbox 3", "chk3", false),
};

for (auto& checkbox : checkboxes) {
	wm.addParameter(&checkbox);
}
```


```html
<input type="checkbox" name="checkbox1" id="checkbox1" value="chk1">
<label for="checkbox1">Checkbox 1</label>
<br>
<input type="checkbox" name="checkbox2" id="checkbox2" value="chk2">
<label for="checkbox2">Checkbox 2</label>
<br>
<input type="checkbox" name="checkbox3" id="checkbox3" value="chk3">
<label for="checkbox3">Checkbox 3</label>
<br>
```

Checkboxes are implemented with the `WiFiManagerParameterCheckbox` class. Checkboxes are declared similarly to regular parameters, but with a boolean 'checked' value in place of `maxLength`:

```cpp
WiFiManagerParameterCheckbox(
    const char* name,
    const char* label,
    const char* value,
    bool        checked = false,
    const char* custom = "",
    int         labelPlacement = WFM_LABEL_AFTER);
```

Because the library uses 'value' to mean both 'default value' and 'current value', checkboxes implement their own value storage to indicate whether the checkbox is "checked" or not. This lets the value persist between server updates while adding only minimal overhead:

```cpp
bool getChecked() const;
void setChecked(bool checked);
```


### Radios



#### Incidental Changes
* Added a `{T}` token for `type` attribute to `wm_consts_en.h` and `wm_consts_fr.h`
* Added a `HTTP_FORM_PARAM_CHECK` string, which compared to `HTTP_FORM_PARAM`:
    * Removes line break 
    * Adds `type` attribute and token
    * Removes `maxlength` attribute
    
---

Please note that this PR incorporates the necessary API changes #1773 and the HTML generation changes from #1774.