### PR TITLE
Enhance cache strategy with board-specific cache keys

### DIFF
--- a/.github/workflows/compile_examples.yaml
+++ b/.github/workflows/compile_examples.yaml
@@ -39,20 +39,27 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ github.ref }}-
+          ${{ runner.os }}-pip-
+        
     - name: Cache PlatformIO
       uses: actions/cache@v2
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.ref }}-
+          ${{ runner.os }}-
+        
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
-    - name: Install 3rd party dependecies
+    - name: Install 3rd party dependencies
       run: | 
         pio lib -g install \
         file://. \
@@ -92,20 +99,25 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ github.ref }}-
+            ${{ runner.os }}-pip-
       - name: Cache PlatformIO
         uses: actions/cache@v2
         with:
           path: ~/.platformio
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.ref }}-
+            ${{ runner.os }}-
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install PlatformIO
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade platformio
-      - name: Install 3rd party dependecies
+      - name: Install 3rd party dependencies
         run: |
           pio lib -g install \
           file://. \
@@ -116,3 +128,4 @@ jobs:
         run: pio ci --board=esp32dev
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
+          

--- a/.github/workflows/compile_library.yml
+++ b/.github/workflows/compile_library.yml
@@ -29,13 +29,18 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.board }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.board }}-
+          ${{ runner.os }}-pip-
     - name: Cache PlatformIO
       uses: actions/cache@v2
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}-${{ matrix.board }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.board }}-
+          ${{ runner.os }}-
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install PlatformIO


### PR DESCRIPTION
### Summary:
This PR refines the caching strategy used in the `Compile Library` GitHub Actions workflow by making cache keys board-specific. Previously, caches for `pip` and `PlatformIO` were shared across all board configurations, which could lead to cache conflicts or inefficiencies. Now, each board (e.g., `nodemcuv2`, `lolin32`) has its own unique cache, improving cache hits and reducing build times.

### Changes:
- Modified cache keys for `pip` and `PlatformIO` to incorporate the board matrix value.
- This change ensures better cache management when multiple boards are being built, preventing cache collisions.
  
### Motivation:
This change improves the efficiency of the CI/CD pipeline by ensuring that the cache is appropriately scoped for each board, optimizing build times for different configurations.
