### PR TITLE
Handle only routes from menu

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1,9 +1,9 @@
 /**
  * WiFiManager.cpp
- * 
+ *
  * WiFiManager, a library for the ESP8266/Arduino platform
  * for configuration of WiFi credentials using a Captive Portal
- * 
+ *
  * @author Creator tzapu
  * @author tablatronix
  * @version 0.0.0
@@ -82,10 +82,10 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
     // Serial.println("cannot set value of this parameter");
     return;
   }
-  
+
   // if(strlen(defaultValue) > length){
   //   // Serial.println("defaultValue length mismatch");
-  //   // return false; //@todo bail 
+  //   // return false; //@todo bail
   // }
 
   if(_length != length || _value == nullptr){
@@ -93,17 +93,17 @@ void WiFiManagerParameter::setValue(const char *defaultValue, int length) {
     if( _value != nullptr){
       delete[] _value;
     }
-    _value  = new char[_length + 1];  
+    _value  = new char[_length + 1];
   }
 
   memset(_value, 0, _length + 1); // explicit null
-  
+
   if (defaultValue != NULL) {
     strncpy(_value, defaultValue, _length);
   }
 }
 const char* WiFiManagerParameter::getValue() const {
-  // Serial.println(printf("Address of _value is %p\n", (void *)_value)); 
+  // Serial.println(printf("Address of _value is %p\n", (void *)_value));
   return _value;
 }
 const char* WiFiManagerParameter::getID() const {
@@ -147,7 +147,7 @@ bool WiFiManager::addParameter(WiFiManagerParameter *p) {
   // init params if never malloc
   if(_params == NULL){
     #ifdef WM_DEBUG_LEVEL
-    DEBUG_WM(WM_DEBUG_DEV,F("allocating params bytes:"),_max_params * sizeof(WiFiManagerParameter*));        
+    DEBUG_WM(WM_DEBUG_DEV,F("allocating params bytes:"),_max_params * sizeof(WiFiManagerParameter*));
     #endif
     _params = (WiFiManagerParameter**)malloc(_max_params * sizeof(WiFiManagerParameter*));
   }
@@ -157,7 +157,7 @@ bool WiFiManager::addParameter(WiFiManagerParameter *p) {
     _max_params += WIFI_MANAGER_MAX_PARAMS;
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_DEV,F("Updated _max_params:"),_max_params);
-    DEBUG_WM(WM_DEBUG_DEV,F("re-allocating params bytes:"),_max_params * sizeof(WiFiManagerParameter*));    
+    DEBUG_WM(WM_DEBUG_DEV,F("re-allocating params bytes:"),_max_params * sizeof(WiFiManagerParameter*));
     #endif
     WiFiManagerParameter** new_params = (WiFiManagerParameter**)realloc(_params, _max_params * sizeof(WiFiManagerParameter*));
     #ifdef WM_DEBUG_LEVEL
@@ -177,7 +177,7 @@ bool WiFiManager::addParameter(WiFiManagerParameter *p) {
 
   _params[_paramsCount] = p;
   _paramsCount++;
-  
+
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(WM_DEBUG_VERBOSE,F("Added Parameter:"),p->getID());
   #endif
@@ -202,7 +202,7 @@ int WiFiManager::getParametersCount() {
 
 /**
  * --------------------------------------------------------------------------------
- *  WiFiManager 
+ *  WiFiManager
  * --------------------------------------------------------------------------------
 **/
 
@@ -212,7 +212,7 @@ WiFiManager::WiFiManager(Print& consolePort):_debugPort(consolePort){
 }
 
 WiFiManager::WiFiManager() {
-  WiFiManagerInit();  
+  WiFiManagerInit();
 }
 
 void WiFiManager::WiFiManagerInit(){
@@ -313,7 +313,7 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
       #endif
       return false;
     }
-    
+
     WiFiSetCountry();
 
     #ifdef ESP32
@@ -333,7 +333,7 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
     }
     #endif
 
-    // if already connected, or try stored connect 
+    // if already connected, or try stored connect
     // @note @todo ESP32 has no autoconnect, so connectwifi will always be called unless user called begin etc before
     // @todo check if correct ssid == saved ssid when already connected
     bool connected = false;
@@ -395,7 +395,7 @@ bool WiFiManager::setupHostname(bool restart){
     DEBUG_WM(WM_DEBUG_DEV,F("No Hostname to set"));
     #endif
     return false;
-  } 
+  }
   else {
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Setting Hostnames: "),_hostname);
@@ -420,7 +420,7 @@ bool WiFiManager::setupHostname(bool restart){
     // @note hostname must be set after STA_START
     // @note, this may have changed at some point, now it wont work, I have to set it before.
     // same for S2, must set it before mode(STA) now
-  
+
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Setting WiFi hostname"));
     #endif
@@ -432,7 +432,7 @@ bool WiFiManager::setupHostname(bool restart){
     //     if(err){
     //         log_e("Could not set hostname! %d", err);
     //         return false;
-    //     } 
+    //     }
     // #ifdef ESP32MDNS_H
       #ifdef WM_MDNS
         #ifdef WM_DEBUG_LEVEL
@@ -492,7 +492,7 @@ bool WiFiManager::startAP(){
 
   //@todo add callback here if needed to modify ap but cannot use setAPStaticIPConfig
   //@todo rework wifi channelsync as it will work unpredictably when not connected in sta
- 
+
   int32_t channel = 0;
   if(_channelSync) channel = WiFi.channel();
   else channel = _apChannel;
@@ -508,26 +508,26 @@ bool WiFiManager::startAP(){
   if (_apPassword != "") {
     if(channel>0){
       ret = WiFi.softAP(_apName.c_str(), _apPassword.c_str(),channel,_apHidden);
-    }  
+    }
     else{
       ret = WiFi.softAP(_apName.c_str(), _apPassword.c_str(),1,_apHidden);//password option
     }
   } else {
     #ifdef WM_DEBUG_LEVEL
-    DEBUG_WM(WM_DEBUG_VERBOSE,F("AP has anonymous access!"));    
+    DEBUG_WM(WM_DEBUG_VERBOSE,F("AP has anonymous access!"));
     #endif
     if(channel>0){
       ret = WiFi.softAP(_apName.c_str(),"",channel,_apHidden);
-    }  
+    }
     else{
       ret = WiFi.softAP(_apName.c_str(),"",1,_apHidden);
-    }  
+    }
   }
 
   if(_debugLevel >= WM_DEBUG_DEV) debugSoftAPConfig();
 
   // @todo add softAP retry here to dela with unknown failures
-  
+
   delay(500); // slight delay to make sure we get an AP IP
   #ifdef WM_DEBUG_LEVEL
   if(!ret) DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] There was a problem starting the AP"));
@@ -569,7 +569,7 @@ void WiFiManager::startWebPortal() {
 void WiFiManager::stopWebPortal() {
   if(!configPortalActive && !webPortalActive) return;
   #ifdef WM_DEBUG_LEVEL
-  DEBUG_WM(WM_DEBUG_VERBOSE,F("Stopping Web Portal"));  
+  DEBUG_WM(WM_DEBUG_VERBOSE,F("Stopping Web Portal"));
   #endif
   webPortalActive = false;
   shutdownConfigPortal();
@@ -601,7 +601,7 @@ boolean WiFiManager::configPortalHasTimeout(){
       DEBUG_WM(F("config portal has timed out"));
       #endif
       return true; // timeout bail, else do debug logging
-    } 
+    }
     else if(_debug && _debugLevel > 0) {
       // log timeout time remaining every 30s
       if((millis() - timer) > logintvl){
@@ -637,27 +637,27 @@ void WiFiManager::setupHTTPServer(){
     _webservercallback(); // @CALLBACK
   }
   // @todo add a new callback maybe, after webserver started, callback cannot override handlers, but can grab them first
-  
+
   /* Setup httpd callbacks, web pages: root, wifi config pages, SO captive portal detectors and not found. */
 
   // G macro workaround for Uri() bug https://github.com/esp8266/Arduino/issues/7102
   server->on(WM_G(R_root),       std::bind(&WiFiManager::handleRoot, this));
-  server->on(WM_G(R_wifi),       std::bind(&WiFiManager::handleWifi, this, true));
-  server->on(WM_G(R_wifinoscan), std::bind(&WiFiManager::handleWifi, this, false));
+  if (_allowAllRoutes || isTokenInMenu(_wifi_token)) server->on(WM_G(R_wifi),       std::bind(&WiFiManager::handleWifi, this, true));
+  if (_allowAllRoutes || isTokenInMenu(_wifinoscan_token)) server->on(WM_G(R_wifinoscan), std::bind(&WiFiManager::handleWifi, this, false));
   server->on(WM_G(R_wifisave),   std::bind(&WiFiManager::handleWifiSave, this));
-  server->on(WM_G(R_info),       std::bind(&WiFiManager::handleInfo, this));
-  server->on(WM_G(R_param),      std::bind(&WiFiManager::handleParam, this));
+  if (_allowAllRoutes || isTokenInMenu(_info_token)) server->on(WM_G(R_info),       std::bind(&WiFiManager::handleInfo, this));
+  if (_allowAllRoutes || isTokenInMenu(_param_token)) server->on(WM_G(R_param),      std::bind(&WiFiManager::handleParam, this));
   server->on(WM_G(R_paramsave),  std::bind(&WiFiManager::handleParamSave, this));
-  server->on(WM_G(R_restart),    std::bind(&WiFiManager::handleReset, this));
-  server->on(WM_G(R_exit),       std::bind(&WiFiManager::handleExit, this));
-  server->on(WM_G(R_close),      std::bind(&WiFiManager::handleClose, this));
-  server->on(WM_G(R_erase),      std::bind(&WiFiManager::handleErase, this, false));
-  server->on(WM_G(R_status),     std::bind(&WiFiManager::handleWiFiStatus, this));
+  if (_allowAllRoutes || isTokenInMenu(_restart_token)) server->on(WM_G(R_restart),    std::bind(&WiFiManager::handleReset, this));
+  if (_allowAllRoutes || isTokenInMenu(_exit_token)) server->on(WM_G(R_exit),       std::bind(&WiFiManager::handleExit, this));
+  if (_allowAllRoutes || isTokenInMenu(_close_token)) server->on(WM_G(R_close),      std::bind(&WiFiManager::handleClose, this));
+  if (_allowAllRoutes || isTokenInMenu(_restart_token)) server->on(WM_G(R_erase),      std::bind(&WiFiManager::handleErase, this, false));
+  if (_allowAllRoutes || isTokenInMenu(_restart_token)) server->on(WM_G(R_status),     std::bind(&WiFiManager::handleWiFiStatus, this));
   server->onNotFound (std::bind(&WiFiManager::handleNotFound, this));
-  
-  server->on(WM_G(R_update), std::bind(&WiFiManager::handleUpdate, this));
+
+  if (_allowAllRoutes || isTokenInMenu(_update_token) || isTokenInMenu(_info_token)) server->on(WM_G(R_update), std::bind(&WiFiManager::handleUpdate, this));
   server->on(WM_G(R_updatedone), HTTP_POST, std::bind(&WiFiManager::handleUpdateDone, this), std::bind(&WiFiManager::handleUpdating, this));
-  
+
   server->begin(); // Web server start
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(WM_DEBUG_VERBOSE,F("HTTP server started"));
@@ -700,14 +700,14 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
   if(configPortalActive){
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Starting Config Portal FAILED, is already running"));
-    #endif    
+    #endif
     return false;
   }
 
   //setup AP
   _apName     = apName; // @todo check valid apname ?
   _apPassword = apPassword;
-  
+
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(WM_DEBUG_VERBOSE,F("Starting Config Portal"));
   #endif
@@ -715,10 +715,10 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
   if(_apName == "") _apName = getDefaultAPName();
 
   if(!validApPassword()) return false;
-  
+
   // HANDLE issues with STA connections, shutdown sta if not connected, or else this will hang channel scanning and softap will not respond
   if(_disableSTA || (!WiFi.isConnected() && _disableSTAConn)){
-    // this fixes most ap problems, however, simply doing mode(WIFI_AP) does not work if sta connection is hanging, must `wifi_station_disconnect` 
+    // this fixes most ap problems, however, simply doing mode(WIFI_AP) does not work if sta connection is hanging, must `wifi_station_disconnect`
     #ifdef WM_DISCONWORKAROUND
       WiFi.mode(WIFI_AP_STA);
     #endif
@@ -762,9 +762,9 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
 
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(WM_DEBUG_DEV,F("setupDNSD"));
-  #endif  
+  #endif
   setupDNSD();
-  
+
 
   if(!_configPortalIsBlocking){
     #ifdef WM_DEBUG_LEVEL
@@ -775,7 +775,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
   }
 
   // enter blocking loop, waiting for config
-  
+
   #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Config Portal Running, blocking, waiting for clients..."));
     if(_configPortalTimeout > 0) DEBUG_WM(WM_DEBUG_VERBOSE,F("Portal Timeout In"),(String)(_configPortalTimeout/1000) + (String)F(" seconds"));
@@ -800,7 +800,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     }
 
     state = processConfigPortal();
-    
+
     // status change, break
     // @todo what is this for, should be moved inside the processor
     // I think.. this is to detect autoconnect by esp in background, there are also many open issues about autoreconnect not working
@@ -831,7 +831,7 @@ boolean WiFiManager::process(){
     #if defined(WM_MDNS) && defined(ESP8266)
     MDNS.update();
     #endif
-	
+
     if(webPortalActive || (configPortalActive && !_configPortalIsBlocking)){
       // if timed out or abort, break
       if(_allowExit && (configPortalHasTimeout() || abort)){
@@ -859,7 +859,7 @@ boolean WiFiManager::process(){
  * [processConfigPortal description]
  * using esp wl_status enums as returns for now, should be fine
  * returns WL_IDLE_STATUS or WL_CONNECTED/WL_CONNECT_FAILED upon connect/save flag
- * 
+ *
  * @return {[type]} [description]
  */
 uint8_t WiFiManager::processConfigPortal(){
@@ -913,7 +913,7 @@ uint8_t WiFiManager::processConfigPortal(){
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] Connect to new AP Failed"));
         #endif
       }
- 
+
       if (_shouldBreakAfterConfig) {
 
         // do save callback
@@ -942,7 +942,7 @@ uint8_t WiFiManager::processConfigPortal(){
       else{
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_VERBOSE,F("Portal is non blocking - remaining open"));
-        #endif        
+        #endif
       }
     }
 
@@ -989,7 +989,7 @@ bool WiFiManager::shutdownConfigPortal(){
 
   bool ret = false;
   ret = WiFi.softAPdisconnect(false);
-  
+
   #ifdef WM_DEBUG_LEVEL
   if(!ret)DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] disconnect configportal - softAPdisconnect FAILED"));
   DEBUG_WM(WM_DEBUG_VERBOSE,F("restoring usermode"),getModeString(_usermode));
@@ -1024,7 +1024,7 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass, bool connect) {
 
   setSTAConfig();
   //@todo catch failures in set_config
-  
+
   // make sure sta is on before `begin` so it does not call enablesta->mode while persistent is ON ( which would save WM AP state to eeprom !)
   // WiFi.setAutoReconnect(false);
   if(_cleanConnect) WiFi_Disconnect(); // disconnect before begin, in case anything is hung, this causes a 2 seconds delay for connect
@@ -1038,7 +1038,7 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass, bool connect) {
   if(_connectRetries > 1){
     if(_aggresiveReconn) delay(1000); // add idle time before recon
     #ifdef WM_DEBUG_LEVEL
-      DEBUG_WM(F("Connect Wifi, ATTEMPT #"),(String)retry+" of "+(String)_connectRetries); 
+      DEBUG_WM(F("Connect Wifi, ATTEMPT #"),(String)retry+" of "+(String)_connectRetries);
       #endif
   }
   // if ssid argument provided connect to that
@@ -1096,8 +1096,8 @@ uint8_t WiFiManager::connectWifi(String ssid, String pass, bool connect) {
 /**
  * connect to a new wifi ap
  * @since $dev
- * @param  String ssid 
- * @param  String pass 
+ * @param  String ssid
+ * @param  String pass
  * @return bool success
  * @return connect only save if false
  */
@@ -1156,7 +1156,7 @@ bool WiFiManager::wifiConnectDefault(){
  */
 bool WiFiManager::setSTAConfig(){
   #ifdef WM_DEBUG_LEVEL
-  DEBUG_WM(WM_DEBUG_DEV,F("STA static IP:"),_sta_static_ip);  
+  DEBUG_WM(WM_DEBUG_DEV,F("STA static IP:"),_sta_static_ip);
   #endif
   bool ret = true;
   if (_sta_static_ip) {
@@ -1180,7 +1180,7 @@ bool WiFiManager::setSTAConfig(){
       if(!ret) DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] wifi config failed"));
       else DEBUG_WM(F("STA IP set:"),WiFi.localIP());
       #endif
-  } 
+  }
   else {
       #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(WM_DEBUG_VERBOSE,F("setSTAConfig static ip not set, skipping"));
@@ -1203,7 +1203,7 @@ void WiFiManager::updateConxResult(uint8_t status){
       // if(_lastconxresult == WL_CONNECT_FAILED){
       if(_lastconxresult == WL_CONNECT_FAILED || _lastconxresult == WL_DISCONNECTED){
         #ifdef WM_DEBUG_LEVEL
-        DEBUG_WM(WM_DEBUG_DEV,F("lastconxresulttmp:"),getWLStatusString(_lastconxresulttmp));            
+        DEBUG_WM(WM_DEBUG_DEV,F("lastconxresulttmp:"),getWLStatusString(_lastconxresulttmp));
         #endif
         if(_lastconxresulttmp != WL_IDLE_STATUS){
           _lastconxresult    = _lastconxresulttmp;
@@ -1214,10 +1214,10 @@ void WiFiManager::updateConxResult(uint8_t status){
     #endif
 }
 
- 
+
 uint8_t WiFiManager::waitForConnectResult() {
   #ifdef WM_DEBUG_LEVEL
-  if(_connectTimeout > 0) DEBUG_WM(WM_DEBUG_DEV,_connectTimeout,F("ms connectTimeout set")); 
+  if(_connectTimeout > 0) DEBUG_WM(WM_DEBUG_DEV,_connectTimeout,F("ms connectTimeout set"));
   #endif
   return waitForConnectResult(_connectTimeout);
 }
@@ -1240,7 +1240,7 @@ uint8_t WiFiManager::waitForConnectResult(uint32_t timeout) {
   DEBUG_WM(WM_DEBUG_VERBOSE,timeout,F("ms timeout, waiting for connect..."));
   #endif
   uint8_t status = WiFi.status();
-  
+
   while(millis() < timeoutmillis) {
     status = WiFi.status();
     // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not to timeout if waiting on IP
@@ -1261,7 +1261,7 @@ void WiFiManager::startWPS() {
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(F("START WPS"));
   #endif
-  #ifdef ESP8266  
+  #ifdef ESP8266
     WiFi.beginWPSConfig();
   #else
     // @todo
@@ -1311,7 +1311,7 @@ void WiFiManager::HTTPSend(const String &content){
   server->send(200, FPSTR(HTTP_HEAD_CT), content);
 }
 
-/** 
+/**
  * HTTPD handler for page requests
  */
 void WiFiManager::handleRequest() {
@@ -1327,7 +1327,7 @@ void WiFiManager::handleRequest() {
   // 2.3 NO AUTH available
   bool testauth = false;
   if(!testauth) return;
-  
+
   DEBUG_WM(WM_DEBUG_DEV,F("DOING AUTH"));
   bool res = server->authenticate("admin","12345");
   if(!res){
@@ -1338,7 +1338,7 @@ void WiFiManager::handleRequest() {
   }
 }
 
-/** 
+/**
  * HTTPD CALLBACK root or redirect to captive portal
  */
 void WiFiManager::handleRoot() {
@@ -1393,10 +1393,10 @@ void WiFiManager::handleWifi(boolean scan) {
     pitem.replace(FPSTR(T_p), WiFi_psk());
   }
   else if(WiFi_psk() != ""){
-    pitem.replace(FPSTR(T_p),FPSTR(S_passph));    
+    pitem.replace(FPSTR(T_p),FPSTR(S_passph));
   }
   else {
-    pitem.replace(FPSTR(T_p),"");    
+    pitem.replace(FPSTR(T_p),"");
   }
 
   page += pitem;
@@ -1451,7 +1451,7 @@ void WiFiManager::handleParam(){
 
 
 String WiFiManager::getMenuOut(){
-  String page;  
+  String page;
 
   for(auto menuId :_menuIds ){
     if((String)_menutokens[menuId] == "param" && _paramsCount == 0) continue; // no params set, omit params from menu, @todo this may be undesired by someone, use only menu to force?
@@ -1475,7 +1475,7 @@ void WiFiManager::WiFi_scanComplete(int networksFound){
   _lastscan = millis();
   _numNetworks = networksFound;
   #ifdef WM_DEBUG_LEVEL
-  DEBUG_WM(WM_DEBUG_VERBOSE,F("WiFi Scan ASYNC completed"), "in "+(String)(_lastscan - _startscan)+" ms");  
+  DEBUG_WM(WM_DEBUG_VERBOSE,F("WiFi Scan ASYNC completed"), "in "+(String)(_lastscan - _startscan)+" ms");
   DEBUG_WM(WM_DEBUG_VERBOSE,F("WiFi Scan ASYNC found:"),_numNetworks);
   #endif
 }
@@ -1483,7 +1483,7 @@ void WiFiManager::WiFi_scanComplete(int networksFound){
 bool WiFiManager::WiFi_scanNetworks(){
   return WiFi_scanNetworks(false,false);
 }
- 
+
 bool WiFiManager::WiFi_scanNetworks(unsigned int cachetime,bool async){
     return WiFi_scanNetworks(millis()-_lastscan > cachetime,async);
 }
@@ -1498,7 +1498,7 @@ bool WiFiManager::WiFi_scanNetworks(bool force,bool async){
     #endif
 
     // if 0 networks, rescan @note this was a kludge, now disabling to test real cause ( maybe wifi not init etc)
-    // enable only if preload failed? 
+    // enable only if preload failed?
     if(_numNetworks == 0 && _autoforcerescan){
       DEBUG_WM(WM_DEBUG_DEV,"NO APs found forcing new scan");
       force = true;
@@ -1540,7 +1540,7 @@ bool WiFiManager::WiFi_scanNetworks(bool force,bool async){
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] scan failed"));
         #endif
-      }  
+      }
       else if(res == WIFI_SCAN_RUNNING){
         #ifdef WM_DEBUG_LEVEL
         DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] scan waiting"));
@@ -1632,14 +1632,14 @@ String WiFiManager::WiFiManager::getScanItemOut(){
       HTTP_ITEM_STR.replace("{h}",_scanDispOptions ? "" : "h");
       HTTP_ITEM_STR.replace("{qi}", FPSTR(HTTP_ITEM_QI));
       HTTP_ITEM_STR.replace("{h}",_scanDispOptions ? "h" : "");
- 
+
       // set token precheck flags
       bool tok_r = HTTP_ITEM_STR.indexOf(FPSTR(T_r)) > 0;
       bool tok_R = HTTP_ITEM_STR.indexOf(FPSTR(T_R)) > 0;
       bool tok_e = HTTP_ITEM_STR.indexOf(FPSTR(T_e)) > 0;
       bool tok_q = HTTP_ITEM_STR.indexOf(FPSTR(T_q)) > 0;
       bool tok_i = HTTP_ITEM_STR.indexOf(FPSTR(T_i)) > 0;
-      
+
       //display networks in page
       for (int i = 0; i < n; i++) {
         if (indices[i] == -1) continue; // skip dups
@@ -1699,7 +1699,7 @@ String WiFiManager::getIpForm(String id, String title, String value){
     item.replace(FPSTR(T_l), F("15"));
     item.replace(FPSTR(T_v), value);
     item.replace(FPSTR(T_c), "");
-    return item;  
+    return item;
 }
 
 String WiFiManager::getStaticOut(){
@@ -1816,7 +1816,7 @@ void WiFiManager::handleWiFiStatus(){
   HTTPSend(page);
 }
 
-/** 
+/**
  * HTTPD CALLBACK save form and redirect to WLAN config page again
  */
 void WiFiManager::handleWifiSave() {
@@ -1834,7 +1834,7 @@ void WiFiManager::handleWifiSave() {
     _ssid = WiFi_SSID(true); // password change, placeholder ssid, @todo compare pass to old?, confirm ssid is clean
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Detected WiFi password change"));
-    #endif    
+    #endif
   }
 
   #ifdef WM_DEBUG_LEVEL
@@ -1885,7 +1885,7 @@ void WiFiManager::handleWifiSave() {
   }
 
   if (_presavewificallback != NULL) {
-    _presavewificallback();  // @CALLBACK 
+    _presavewificallback();  // @CALLBACK
   }
 
   if(_paramsInWifi) doParamSave();
@@ -1928,7 +1928,7 @@ void WiFiManager::handleParamSave() {
 
   String page = getHTTPHead(FPSTR(S_titleparamsaved), FPSTR(C_param)); // @token titleparamsaved
   page += FPSTR(HTTP_PARAMSAVED);
-  if(_showBack) page += FPSTR(HTTP_BACKBTN); 
+  if(_showBack) page += FPSTR(HTTP_BACKBTN);
   page += getHTTPEnd();
 
   HTTPSend(page);
@@ -1981,10 +1981,10 @@ void WiFiManager::doParamSave(){
    if ( _saveparamscallback != NULL) {
     _saveparamscallback();  // @CALLBACK
   }
-   
+
 }
 
-/** 
+/**
  * HTTPD CALLBACK info page
  */
 void WiFiManager::handleInfo() {
@@ -2041,11 +2041,11 @@ void WiFiManager::handleInfo() {
       F("chipid"),
       F("chiprev"),
       F("idesize"),
-      F("flashsize"),      
+      F("flashsize"),
       F("cpufreq"),
       F("freeheap"),
       F("memsketch"),
-      F("memsmeter"),      
+      F("memsmeter"),
       F("lastreset"),
       F("temp"),
       // F("hall"),
@@ -2146,14 +2146,14 @@ String WiFiManager::getInfoData(String id){
       p.replace(FPSTR(T_1),(String)ESP.getFlashChipRealSize());
     #elif defined ESP32
       p = FPSTR(HTTP_INFO_psrsize);
-      p.replace(FPSTR(T_1),(String)ESP.getPsramSize());      
+      p.replace(FPSTR(T_1),(String)ESP.getPsramSize());
     #endif
   }
   else if(id==F("corever")){
     #ifdef ESP8266
       p = FPSTR(HTTP_INFO_corever);
       p.replace(FPSTR(T_1),(String)ESP.getCoreVersion());
-    #endif      
+    #endif
   }
   #ifdef ESP8266
   else if(id==F("bootver")){
@@ -2292,7 +2292,7 @@ String WiFiManager::getInfoData(String id){
     p.replace(FPSTR(T_1),(String)temperatureRead());
     p.replace(FPSTR(T_2),(String)((temperatureRead()+32)*1.8f));
   }
-  // else if(id==F("hall")){ 
+  // else if(id==F("hall")){
   //   p = FPSTR(HTTP_INFO_hall);
   //   p.replace(FPSTR(T_1),(String)hallRead()); // hall sensor reads can cause issues with adcs
   // }
@@ -2329,7 +2329,7 @@ String WiFiManager::getInfoData(String id){
   return p;
 }
 
-/** 
+/**
  * HTTPD CALLBACK exit, closes configportal if blocking, if non blocking undefined
  */
 void WiFiManager::handleExit() {
@@ -2347,7 +2347,7 @@ void WiFiManager::handleExit() {
   abort = true;
 }
 
-/** 
+/**
  * HTTPD CALLBACK reset page
  */
 void WiFiManager::handleReset() {
@@ -2368,7 +2368,7 @@ void WiFiManager::handleReset() {
   reboot();
 }
 
-/** 
+/**
  * HTTPD CALLBACK erase page
  */
 
@@ -2401,10 +2401,10 @@ void WiFiManager::handleErase(boolean opt) {
   	DEBUG_WM(F("RESETTING ESP"));
     #endif
   	reboot();
-  }	
+  }
 }
 
-/** 
+/**
  * HTTPD CALLBACK 404
  */
 void WiFiManager::handleNotFound() {
@@ -2434,13 +2434,13 @@ void WiFiManager::handleNotFound() {
 
 /**
  * HTTPD redirector
- * Redirect to captive portal if we got a request for another domain. 
- * Return true in that case so the page handler do not try to handle the request again. 
+ * Redirect to captive portal if we got a request for another domain.
+ * Return true in that case so the page handler do not try to handle the request again.
  */
 boolean WiFiManager::captivePortal() {
-  
+
   if(!_enableCaptivePortal || !configPortalActive) return false; // skip redirections if cp not enabled or not in ap mode
-  
+
   String serverLoc =  toStringIp(server->client().localIP());
 
   #ifdef WM_DEBUG_LEVEL
@@ -2455,10 +2455,10 @@ boolean WiFiManager::captivePortal() {
     else
       serverLoc = toStringIp(WiFi.localIP());
   }
-  
+
   if(_httpPort != 80) serverLoc += ":" + (String)_httpPort; // add port if not default
   bool doredirect = serverLoc != server->hostHeader(); // redirect if hostheader not server ip, prevent redirect loops
-  
+
   if (doredirect) {
     #ifdef WM_DEBUG_LEVEL
     DEBUG_WM(WM_DEBUG_VERBOSE,F("<- Request redirected to captive portal"));
@@ -2528,7 +2528,7 @@ void WiFiManager::reportStatus(String &page){
       else{
         str.replace(FPSTR(T_c),"");
         str.replace(FPSTR(T_r),"");
-      } 
+      }
     }
   }
   else {
@@ -2554,7 +2554,7 @@ bool WiFiManager::stopConfigPortal(){
     abort = true;
     return true;
   }
-  return shutdownConfigPortal();  
+  return shutdownConfigPortal();
 }
 
 /**
@@ -2569,7 +2569,7 @@ bool WiFiManager::disconnect(){
     DEBUG_WM(WM_DEBUG_VERBOSE,F("Disconnecting: Not connected"));
     #endif
     return false;
-  }  
+  }
   #ifdef WM_DEBUG_LEVEL
   DEBUG_WM(F("Disconnecting"));
   #endif
@@ -2659,7 +2659,7 @@ void WiFiManager::resetSettings() {
   if (_resetcallback != NULL){
       _resetcallback();  // @CALLBACK
   }
-  
+
   #ifdef ESP32
     WiFi.disconnect(true,true);
   #else
@@ -2728,7 +2728,7 @@ void WiFiManager::setSaveConnectTimeout(unsigned long seconds) {
 }
 
 /**
- * Set save portal connect on save option, 
+ * Set save portal connect on save option,
  * if false, will only save credentials not connect
  * @access public
  * @param {[type]} bool connect [description]
@@ -2820,7 +2820,7 @@ void WiFiManager::setBreakAfterConfig(boolean shouldBreak) {
 
 /**
  * setAPCallback, set a callback when softap is started
- * @access public 
+ * @access public
  * @param {[type]} void (*func)(WiFiManager* wminstance)
  */
 void WiFiManager::setAPCallback( std::function<void(WiFiManager*)> func ) {
@@ -2831,7 +2831,7 @@ void WiFiManager::setAPCallback( std::function<void(WiFiManager*)> func ) {
  * setWebServerCallback, set a callback after webserver is reset, and before routes are setup
  * if we set webserver handlers before wm, they are used and wm is not by esp webserver
  * on events cannot be overrided once set, and are not mutiples
- * @access public 
+ * @access public
  * @param {[type]} void (*func)(void)
  */
 void WiFiManager::setWebServerCallback( std::function<void()> func ) {
@@ -3239,12 +3239,21 @@ void WiFiManager::setMenu(std::vector<const char *>& menu){
   #endif
 }
 
+bool WiFiManager::isTokenInMenu(const char * token){
+  for(auto menuId :_menuIds ){
+    if((String)_menutokens[menuId] == token){
+      return true;
+    }
+  }
+  return false;
+}
+
 
 /**
  * set params as sperate page not in wifi
- * NOT COMPATIBLE WITH setMenu! 
+ * NOT COMPATIBLE WITH setMenu!
  * @todo scan menuids and insert param after wifi or something, same for ota
- * @param bool enable 
+ * @param bool enable
  * @since $dev
  */
 void WiFiManager::setParamsPage(bool enable){
@@ -3289,13 +3298,13 @@ bool WiFiManager::getWiFiIsSaved(){
 /**
  * getDefaultAPName
  * @since $dev
- * @return string 
+ * @return string
  */
 String WiFiManager::getDefaultAPName(){
   String hostString = String(WIFI_getChipId(),HEX);
   hostString.toUpperCase();
   // char hostString[16] = {0};
-  // sprintf(hostString, "%06X", ESP.getChipId());  
+  // sprintf(hostString, "%06X", ESP.getChipId());
   return _wifissidprefix + "_" + hostString;
 }
 
@@ -3332,6 +3341,13 @@ void WiFiManager::setHttpPort(uint16_t port){
   _httpPort = port;
 }
 
+/**
+ * setAllowAllRoutes
+ * @param bool enable, enable acccess all pages even if not in menu
+ */
+void WiFiManager::setAllowAllRoutes(bool enable){
+  _allowAllRoutes = enable;
+}
 
 bool WiFiManager::preloadWiFi(String ssid, String pass){
   _defaultssid = ssid;
@@ -3359,7 +3375,7 @@ String WiFiManager::getWiFiSSID(bool persistent){
  */
 String WiFiManager::getWiFiPass(bool persistent){
   return WiFi_psk(persistent);
-} 
+}
 
 // DEBUG
 // @todo fix DEBUG_WM(0,0);
@@ -3388,7 +3404,7 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
     // uint16_t max;
     // uint8_t frag;
     // ESP.getHeapStats(&free, &max, &frag);// @todo Does not exist in 2.3.0
-    // _debugPort.printf("[MEM] free: %5d | max: %5d | frag: %3d%% \n", free, max, frag); 
+    // _debugPort.printf("[MEM] free: %5d | max: %5d | frag: %3d%% \n", free, max, frag);
     #elif defined ESP32
     // total_free_bytes;      ///<  Total free bytes in the heap. Equivalent to multi_free_heap_size().
     // total_allocated_bytes; ///<  Total bytes allocated to data in the heap.
@@ -3422,7 +3438,7 @@ void WiFiManager::DEBUG_WM(wm_debuglevel_t level,Generic text,Genericb textb) {
  * @return {[type]} [description]
  */
 void WiFiManager::debugSoftAPConfig(){
-    
+
     #ifdef ESP8266
       softap_config config;
       wifi_softap_get_config(&config);
@@ -3449,7 +3465,7 @@ void WiFiManager::debugSoftAPConfig(){
     DEBUG_WM(F("ssid_hidden:     "),config.ssid_hidden);
     DEBUG_WM(F("max_connection:  "),config.max_connection);
     #endif
-    #if !defined(WM_NOCOUNTRY) 
+    #if !defined(WM_NOCOUNTRY)
     #ifdef WM_DEBUG_LEVEL
       DEBUG_WM(F("country:         "),(String)country.cc);
       #endif
@@ -3614,7 +3630,7 @@ bool WiFiManager::WiFiSetCountry(){
   esp_err_t err = ESP_OK;
   // @todo check if wifi is init, no idea how, doesnt seem to be exposed atm ( check again it might be now! )
   if(WiFi.getMode() == WIFI_MODE_NULL){
-      DEBUG_WM(WM_DEBUG_ERROR,"[ERROR] cannot set country, wifi not init");        
+      DEBUG_WM(WM_DEBUG_ERROR,"[ERROR] cannot set country, wifi not init");
   } // exception if wifi not init!
   // Assumes that _wificountry is set to one of the supported country codes : "01"(world safe mode) "AT","AU","BE","BG","BR",
   //               "CA","CH","CN","CY","CZ","DE","DK","EE","ES","FI","FR","GB","GR","HK","HR","HU",
@@ -3639,7 +3655,7 @@ bool WiFiManager::WiFiSetCountry(){
     }
   #endif
   ret = err == ESP_OK;
-  
+
   #elif defined(ESP8266) && !defined(WM_NOCOUNTRY)
        // if(WiFi.getMode() == WIFI_OFF); // exception if wifi not init!
        if(_wificountry == "US") ret = wifi_set_country((wifi_country_t*)&WM_COUNTRY_US);
@@ -3649,15 +3665,15 @@ bool WiFiManager::WiFiSetCountry(){
   else DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] country code not found"));
   #endif
   #endif
-  
+
   #ifdef WM_DEBUG_LEVEL
   if(ret) DEBUG_WM(WM_DEBUG_VERBOSE,F("[OK] esp_wifi_set_country: "),_wificountry);
-  else DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] esp_wifi_set_country failed"));  
+  else DEBUG_WM(WM_DEBUG_ERROR,F("[ERROR] esp_wifi_set_country failed"));
   #endif
   return ret;
 }
 
-// set mode ignores WiFi.persistent 
+// set mode ignores WiFi.persistent
 bool WiFiManager::WiFi_Mode(WiFiMode_t m,bool persistent) {
     bool ret;
     #ifdef ESP8266
@@ -3690,7 +3706,7 @@ bool WiFiManager::WiFi_Disconnect() {
           #endif
           ETS_UART_INTR_DISABLE(); // @todo possibly not needed
           ret = wifi_station_disconnect();
-          ETS_UART_INTR_ENABLE();        
+          ETS_UART_INTR_ENABLE();
           return ret;
       }
     #elif defined(ESP32)
@@ -3746,7 +3762,7 @@ bool WiFiManager::WiFi_eraseConfig() {
     #endif
 
     #ifdef ESP8266
-      #ifndef WM_FIXERASECONFIG 
+      #ifndef WM_FIXERASECONFIG
         return ESP.eraseConfig();
       #else
         // erase config BUG replacement
@@ -3796,7 +3812,7 @@ String WiFiManager::WiFi_SSID(bool persistent) const{
     memcpy(tmp, conf.ssid, sizeof(conf.ssid));
     tmp[32] = 0; //nullterm in case of 32 char ssid
     return String(reinterpret_cast<char*>(tmp));
-    
+
     #elif defined(ESP32)
     // bool res = WiFi.wifiLowLevelInit(true); // @todo fix for S3, not found
     // wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
@@ -3829,7 +3845,7 @@ String WiFiManager::WiFi_psk(bool persistent) const {
     memcpy(tmp, conf.password, sizeof(conf.password));
     tmp[64] = 0; //null term in case of 64 byte psk
     return String(reinterpret_cast<char*>(tmp));
-    
+
     #elif defined(ESP32)
     // only if wifi is init
     if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
@@ -3874,7 +3890,7 @@ String WiFiManager::WiFi_psk(bool persistent) const {
       if(info.wifi_sta_disconnected.reason == WIFI_REASON_ASSOC_FAIL){
         if(_aggresiveReconn && _connectRetries<4) _connectRetries=4;
         DEBUG_WM(WM_DEBUG_VERBOSE,F("[EVENT] WIFI_REASON: AUTH FAIL"));
-      }  
+      }
       #endif
       #ifdef esp32autoreconnect
       #ifdef WM_DEBUG_LEVEL
@@ -3936,7 +3952,7 @@ void WiFiManager::handleUpdating(){
   // combine route handlers into one callback and use argument or post checking instead of mutiple functions maybe, if POST process else server upload page?
   // [x] add upload checking, do we need too check file?
   // convert output to debugger if not moving to example
-	
+
   // if (captivePortal()) return; // If captive portal redirect instead of displaying the page
   bool error = false;
   unsigned long _configPortalTimeoutSAV = _configPortalTimeout; // store cp timeout
@@ -3950,7 +3966,7 @@ void WiFiManager::handleUpdating(){
 	if (upload.status == UPLOAD_FILE_START) {
 	  // if(_debug) Serial.setDebugOutput(true);
     uint32_t maxSketchSpace;
-    
+
     // Use new callback for before OTA update
     if (_preotaupdatecallback != NULL) {
       _preotaupdatecallback();  // @CALLBACK

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -1,9 +1,9 @@
 /**
  * WiFiManager.h
- * 
+ *
  * WiFiManager, a library for the ESP8266/Arduino platform
  * for configuration of WiFi credentials using a Captive Portal
- * 
+ *
  * @author Creator tzapu
  * @author tablatronix
  * @version 0.0.0
@@ -24,14 +24,14 @@
 
 // #define WM_MDNS            // includes MDNS, also set MDNS with sethostname
 // #define WM_FIXERASECONFIG  // use erase flash fix
-// #define WM_ERASE_NVS       // esp32 erase(true) will erase NVS 
+// #define WM_ERASE_NVS       // esp32 erase(true) will erase NVS
 // #define WM_RTC             // esp32 info page will include reset reasons
 
 // #define WM_JSTEST                      // build flag for enabling js xhr tests
 // #define WIFI_MANAGER_OVERRIDE_STRINGS // build flag for using own strings include
 
 #ifdef ARDUINO_ESP8266_RELEASE_2_3_0
-#warning "ARDUINO_ESP8266_RELEASE_2_3_0, some WM features disabled" 
+#warning "ARDUINO_ESP8266_RELEASE_2_3_0, some WM features disabled"
 // @todo check failing on platform = espressif8266@1.7.3
 #define WM_NOASYNC         // esp8266 no async scan wifi
 #define WM_NOCOUNTRY       // esp8266 no country
@@ -77,15 +77,15 @@
         #include <ESP8266mDNS.h>
     #endif
 
-    #define WIFI_getChipId() ESP.getChipId() 
+    #define WIFI_getChipId() ESP.getChipId()
     #define WM_WIFIOPEN   ENC_TYPE_NONE
 
 #elif defined(ESP32)
 
     #include <WiFi.h>
-    #include <esp_wifi.h>  
+    #include <esp_wifi.h>
     #include <Update.h>
-    
+
     #define WIFI_getChipId() (uint32_t)ESP.getEfuseMac()
     #define WM_WIFIOPEN   WIFI_AUTH_OPEN
 
@@ -142,7 +142,7 @@
 
 // prep string concat vars
 #define WM_STRING2(x) #x
-#define WM_STRING(x) WM_STRING2(x)    
+#define WM_STRING(x) WM_STRING2(x)
 
 // #include <esp_idf_version.h>
 #ifdef ESP_IDF_VERSION
@@ -150,7 +150,7 @@
     // #pragma message "ESP_IDF_VERSION_MINOR = " WM_STRING(ESP_IDF_VERSION_MINOR)
     // #pragma message "ESP_IDF_VERSION_PATCH = " WM_STRING(ESP_IDF_VERSION_PATCH)
     #define VER_IDF_STR WM_STRING(ESP_IDF_VERSION_MAJOR)  "."  WM_STRING(ESP_IDF_VERSION_MINOR)  "."  WM_STRING(ESP_IDF_VERSION_PATCH)
-#else 
+#else
     #define VER_IDF_STR "Unknown"
 #endif
 
@@ -179,7 +179,7 @@
         #define VER_ARDUINO_STR "Unknown"
         #endif
     #endif
-#else 
+#else
 #define VER_ARDUINO_STR "Unknown"
 #endif
 
@@ -197,7 +197,7 @@
 
 class WiFiManagerParameter {
   public:
-    /** 
+    /**
         Create custom parameters that can be added to the WiFiManager setup web page
         @id is used for HTTP queries and must not contain spaces nor other special characters
     */
@@ -228,7 +228,7 @@ class WiFiManagerParameter {
     char       *_value;
     int         _length;
     int         _labelPlacement;
-  
+
     const char *_customHTML;
     friend class WiFiManager;
 };
@@ -262,8 +262,8 @@ class WiFiManager
 
     //manually stop the config portal if started manually, stop immediatly if non blocking, flag abort if blocking
     bool          stopConfigPortal();
-    
-    //manually start the web portal, autoconnect does this automatically on connect failure    
+
+    //manually start the web portal, autoconnect does this automatically on connect failure
     void          startWebPortal();
 
     //manually stop the web portal if started manually
@@ -338,13 +338,13 @@ class WiFiManager
 
     // sets number of retries for autoconnect, force retry after wait failure exit
     void          setConnectRetries(uint8_t numRetries); // default 1
-    
+
     //sets timeout for which to attempt connecting on saves, useful if there are bugs in esp waitforconnectloop
     void          setSaveConnectTimeout(unsigned long seconds);
-    
+
     // lets you disable automatically connecting after save from webportal
     void          setSaveConnect(bool connect = true);
-    
+
     // toggle debug output
     void          setDebugOutput(boolean debug);
     void          setDebugOutput(boolean debug, String prefix); // log line prefix, default "*wm:"
@@ -352,24 +352,24 @@ class WiFiManager
 
     //set min quality percentage to include in scan, defaults to 8% if not specified
     void          setMinimumSignalQuality(int quality = 8);
-    
+
     //sets a custom ip /gateway /subnet configuration
     void          setAPStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn);
-    
+
     //sets config for a static IP
     void          setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn);
-    
+
     //sets config for a static IP with DNS
     void          setSTAStaticIPConfig(IPAddress ip, IPAddress gw, IPAddress sn, IPAddress dns);
-    
+
     //if this is set, it will exit after config, even if connection is unsuccessful.
     void          setBreakAfterConfig(boolean shouldBreak);
-    
-    // if this is set, portal will be blocking and wait until save or exit, 
+
+    // if this is set, portal will be blocking and wait until save or exit,
     // is false user must manually `process()` to handle config portal,
     // setConfigPortalTimeout is ignored in this mode, user is responsible for closing configportal
     void          setConfigPortalBlocking(boolean shouldBlock);
-    
+
     //add custom html at inside <head> for all pages
     void          setCustomHeadElement(const char* html);
 
@@ -384,34 +384,34 @@ class WiFiManager
 
     //if this is true, remove duplicated Access Points - defaut true
     void          setRemoveDuplicateAPs(boolean removeDuplicates);
-    
+
     //setter for ESP wifi.persistent so we can remember it and restore user preference, as WIFi._persistent is protected
     void          setRestorePersistent(boolean persistent);
-    
+
     //if true, always show static net inputs, IP, subnet, gateway, else only show if set via setSTAStaticIPConfig
     void          setShowStaticFields(boolean alwaysShow);
-    
+
     //if true, always show static dns, esle only show if set via setSTAStaticIPConfig
     void          setShowDnsFields(boolean alwaysShow);
-    
+
     // toggle showing the saved wifi password in wifi form, could be a security issue.
     void          setShowPassword(boolean show);
-    
+
     //if false, disable captive portal redirection
     void          setCaptivePortalEnable(boolean enabled);
-    
+
     //if false, timeout captive portal even if a STA client connected to softAP (false), suggest disabling if captiveportal is open
     void          setAPClientCheck(boolean enabled);
-    
-    //if true, reset timeout when webclient connects (true), suggest disabling if captiveportal is open    
+
+    //if true, reset timeout when webclient connects (true), suggest disabling if captiveportal is open
     void          setWebPortalClientCheck(boolean enabled);
-    
+
     // if true, enable autoreconnecting
     void          setWiFiAutoReconnect(boolean enabled);
-    
+
     // if true, wifiscan will show percentage instead of quality icons, until we have better templating
     void          setScanDispPerc(boolean enabled);
-    
+
     // if true (default) then start the config portal from autoConnect if connection failed
     void          setEnableConfigPortal(boolean enable);
 
@@ -430,10 +430,10 @@ class WiFiManager
 
     // set ap channel
     void          setWiFiAPChannel(int32_t channel);
-    
+
     // set ap hidden
     void          setWiFiAPHidden(bool hidden); // default false
-    
+
     // clean connect, always disconnect before connecting
     void          setCleanConnect(bool enable); // default false
 
@@ -441,7 +441,9 @@ class WiFiManager
     // see _menutokens for ids
     void          setMenu(std::vector<const char*>& menu);
     void          setMenu(const char* menu[], uint8_t size);
-    
+
+    bool          isTokenInMenu(const char * token);
+
     // set the webapp title, default WiFiManager
     void          setTitle(String title);
 
@@ -450,10 +452,10 @@ class WiFiManager
 
     // get last connection result, includes autoconnect and wifisave
     uint8_t       getLastConxResult();
-    
+
     // get a status as string
-    String        getWLStatusString(uint8_t status);    
-    String        getWLStatusString();    
+    String        getWLStatusString(uint8_t status);
+    String        getWLStatusString();
 
     // get wifi mode as string
     String        getModeString(uint8_t mode);
@@ -461,7 +463,7 @@ class WiFiManager
     // check if the module has a saved ap to connect to
     bool          getWiFiIsSaved();
 
-    // helper to get saved password, if persistent get stored, else get current if connected    
+    // helper to get saved password, if persistent get stored, else get current if connected
     String        getWiFiPass(bool persistent = true);
 
     // helper to get saved ssid, if persistent get stored, else get current if connected
@@ -475,7 +477,7 @@ class WiFiManager
 
     // helper for html
     String        htmlEntities(String str, bool whitespace = false);
-    
+
     // set the country code for wifi settings, CN
     void          setCountry(String cc);
 
@@ -487,13 +489,16 @@ class WiFiManager
 
     // get default ap esp uses , esp_chipid etc
     String        getDefaultAPName();
-    
+
     // set port of webserver, 80
     void          setHttpPort(uint16_t port);
 
+    // allow acces all pages even not in menu
+    void          setAllowAllRoutes(bool enable);
+
     // check if config portal is active (true)
     bool          getConfigPortalActive();
-    
+
     // check if web portal is active (true)
     bool          getWebPortalActive();
 
@@ -511,7 +516,7 @@ class WiFiManager
     #else
         using WM_WebServer = ESP8266WebServer;
     #endif
-    
+
     std::unique_ptr<WM_WebServer> server;
 
   protected:
@@ -551,7 +556,7 @@ class WiFiManager
     unsigned long _configPortalTimeout    = 0; // ms close config portal loop if set (depending on  _cp/webClientCheck options)
     unsigned long _connectTimeout         = 0; // ms stop trying to connect to ap if set
     unsigned long _saveTimeout            = 0; // ms stop trying to connect to ap on saves, in case bugs in esp waitforconnectresult
-    
+
     WiFiMode_t    _usermode               = WIFI_STA; // Default user mode
     String        _wifissidprefix         = FPSTR(S_ssidpre); // auto apname prefix prefix+chipid
     int           _cpclosedelay           = 2000; // delay before wifisave, prevents captive portal from closing to fast.
@@ -569,6 +574,7 @@ class WiFiManager
                                                    // on some conn failure modes will add delays and many retries to work around esp and ap bugs, ie, anti de-auth protections
                                                    // https://github.com/tzapu/WiFiManager/issues/1067
     bool          _allowExit              = true; // allow exit in nonblocking, else user exit/abort calls will be ignored including cptimeout
+    bool          _allowAllRoutes         = true; // allow all routes even if not added to menu. If false server will serve only pages from menu
 
     #ifdef ESP32
     wifi_event_id_t wm_event_id           = 0;
@@ -586,7 +592,7 @@ class WiFiManager
     boolean       _removeDuplicateAPs     = true;  // remove dup aps from wifiscan
     boolean       _showPassword           = false; // show or hide saved password on wifi form, might be a security issue!
     boolean       _shouldBreakAfterConfig = false; // stop configportal on save failure
-    boolean       _configPortalIsBlocking = true;  // configportal enters blocking loop 
+    boolean       _configPortalIsBlocking = true;  // configportal enters blocking loop
     boolean       _enableCaptivePortal    = true;  // enable captive portal redirection
     boolean       _userpersistent         = true;  // users preffered persistence to restore
     boolean       _wifiAutoReconnect      = true;  // there is no platform getter for this, we must assume its true and make it so
@@ -609,7 +615,7 @@ class WiFiManager
     String        _title                  = FPSTR(S_brand); // app title -  default WiFiManager
 
     // internal options
-    
+
     // wifiscan notes
     // currently disabled due to issues with caching, sometimes first scan is empty esp32 wifi not init yet race, or portals hit server nonstop flood
     // The following are background wifi scanning optimizations
@@ -620,23 +626,23 @@ class WiFiManager
     // async enables asyncronous scans, so they do not block anything
     // the refresh button bypasses cache
     // no aps found is problematic as scans are always going to want to run, leading to page load delays
-    // 
+    //
     // These settings really only make sense with _preloadwifiscan true
     // but not limited to, we could run continuous background scans on various page hits, or xhr hits
     // which would be better coupled with asyncscan
     // atm preload is only done on root hit and startcp
-    // 
+    //
     // preload scanning causes AP to delay showing for users, but also caches and lets the cp load faster once its open
     //  my scan takes 7-10 seconds
 public:
     boolean       _preloadwifiscan        = false; // preload wifiscan if true
     unsigned int  _scancachetime          = 30000; // ms cache time for preload scans
     boolean       _asyncScan              = false; // perform wifi network scan async
-    
+
 protected:
 
     boolean       _autoforcerescan        = false;  // automatically force rescan if scan networks is 0, ignoring cache
-    
+
     boolean       _disableIpFields        = false; // modify function of setShow_X_Fields(false), forces ip fields off instead of default show if set, eg. _staShowStaticFields=-1
 
     String        _wificountry            = "";  // country code, @todo define in strings lang
@@ -650,7 +656,7 @@ protected:
     void          setupConfigPortal();
     bool          shutdownConfigPortal();
     bool          setupHostname(bool restart);
-    
+
 #ifdef NO_EXTRA_4K_HEAP
     boolean       _tryWPS                 = false; // try WPS on save failure, unsupported
     void          startWPS();
@@ -738,12 +744,12 @@ protected:
             #define WM_DISCONWORKAROUND
         #endif
 
-    #else 
+    #else
         #define WM_NOCOUNTRY
     #endif
 
     #ifdef WM_NOCOUNTRY
-        #warning "ESP32 set country unavailable" 
+        #warning "ESP32 set country unavailable"
     #endif
 
 
@@ -785,9 +791,9 @@ protected:
     boolean       portalTimeoutResult = false;
 
     boolean       portalAbortResult   = false;
-    boolean       storeSTAmode        = true; // option store persistent STA mode in connectwifi 
+    boolean       storeSTAmode        = true; // option store persistent STA mode in connectwifi
     int           timer               = 0;    // timer for debug throttle for numclients, and portal timeout messages
-    
+
     // WiFiManagerParameter
     int         _paramsCount          = 0;
     int         _max_params;
@@ -800,7 +806,7 @@ protected:
 
     // build debuglevel support
     // @todo use DEBUG_ESP_x?
-    
+
     // Set default debug level
     #ifndef WM_DEBUG_LEVEL
     #define WM_DEBUG_LEVEL WM_DEBUG_NOTIFY
@@ -813,7 +819,7 @@ protected:
 
     #ifdef WM_DEBUG_LEVEL
     uint8_t _debugLevel = (uint8_t)WM_DEBUG_LEVEL;
-    #else 
+    #else
     uint8_t _debugLevel = 0; // default debug level
     #endif
 


### PR DESCRIPTION
Option "setAllowAllRoutes" allow to decide if server should serve only pages defined in menu on root page. Flag is "true" by default that means all pages will be served even if there is no "direct" access to them from menu. If flag will be set to false and someone want to access to pages not added to menu e.q. by URL server will return 404.