### PR TITLE
Fix watchdog timeout on esp32 when config portal is active

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -812,7 +812,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
 
     if(!configPortalActive) break;
 
-    yield(); // watchdog
+    delay(1); // watchdog
   }
 
   #ifdef WM_DEBUG_LEVEL


### PR DESCRIPTION
Calling `yield()` on the esp32 doesn't let the idle task run and therefore doesn't feed the watchdog. Instead, calling `delay(1)` forces the context change and allows the idle task to run.