### PR TITLE
feature: api endponts

### DIFF
--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -694,6 +694,11 @@ protected:
     boolean       configPortalHasTimeout();
     uint8_t       processConfigPortal();
     void          stopCaptivePortal();
+
+    // webserver api handlers
+    void          handleAPIWifi();
+    void          handleAPISaveWifi();
+
 	// OTA Update handler
 	void          handleUpdate();
 	void          handleUpdating();
@@ -762,6 +767,10 @@ protected:
     String        getHTTPHead(String title, String classes = "");
     String        getHTTPEnd();
     String        getMenuOut();
+
+    // api output helpers
+    String        getScanJSON();
+
     //helpers
     boolean       isIp(String str);
     String        toStringIp(IPAddress ip);

--- a/wm_consts_en.h
+++ b/wm_consts_en.h
@@ -62,6 +62,9 @@ const char R_status[]             PROGMEM = "/status";
 const char R_update[]             PROGMEM = "/update";
 const char R_updatedone[]         PROGMEM = "/u";
 
+// Api routes
+const char R_API_wifi[] PROGMEM = "/api/wifi";
+const char R_API_wifisave[] PROGMEM = "/api/wifisave";
 
 // Classes
 const char C_root[]               PROGMEM = "home";
@@ -81,6 +84,7 @@ const char S_gw[]                 PROGMEM = "gw";
 const char S_sn[]                 PROGMEM = "sn";
 const char S_dns[]                PROGMEM = "dns";
 
+const char S_nonetworks_json[]    PROGMEM = "{ \"networks\" : [] }";
 
 
 //Tokens

--- a/wm_consts_fr.h
+++ b/wm_consts_fr.h
@@ -63,6 +63,9 @@ const char R_status[]             PROGMEM = "/status";
 const char R_update[]             PROGMEM = "/update";
 const char R_updatedone[]         PROGMEM = "/u";
 
+// Api routes
+const char R_API_wifi[] PROGMEM = "/api/wifi";
+const char R_API_wifisave[] PROGMEM = "/api/wifisave";
 
 // Classes
 const char C_root[]               PROGMEM = "home";
@@ -82,7 +85,7 @@ const char S_gw[]                 PROGMEM = "gw";
 const char S_sn[]                 PROGMEM = "sn";
 const char S_dns[]                PROGMEM = "dns";
 
-
+const char S_nonetworks_json[]    PROGMEM = "{ \"networks\" : [] }";
 
 //Tokens
 //@todo consolidate and reduce


### PR DESCRIPTION
Makes things easier if someone wants to interact with WifiManager but without the need of using the Web UI. Useful if you want to integrate WifiManager but with a native screen in mobile apps.

The 2 API routes are:

- `/api/wifi`: Returns a JSON with list of available networks. JSON content is:
   - SSID
   - Strength
   - Password Secured
- `/api/wifisave`: Saves WIFI credentials (Same as /wifisave but returning a JSON)