### PR TITLE
Add clearParameter() to reset all custom parameters

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -201,6 +201,18 @@ int WiFiManager::getParametersCount() {
 }
 
 /**
+ *  [clearParameter description]
+ * @access public
+ */
+void WiFiManager::clearParameter() {
+  if (_params != NULL) {
+    free(_params);
+    _params = NULL;
+    _paramsCount = 0;
+  }
+}
+
+/**
  * --------------------------------------------------------------------------------
  *  WiFiManager 
  * --------------------------------------------------------------------------------

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -298,6 +298,9 @@ class WiFiManager
     // returns the Parameters Count
     int           getParametersCount();
 
+    // clear all custom parameters.
+    void          clearParameter();
+
     // SET CALLBACKS
 
     //called after AP mode and config portal has started


### PR DESCRIPTION
### Summary
Adds `clearParameter()` method to WiFiManager.

### Motivation
Allows resetting all custom parameters added via addParameter(),
making it easier to rebuild configuration pages dynamically without recreating the WiFiManager instance.
